### PR TITLE
Correct case of js filenames for case-sensitive servers

### DIFF
--- a/igv.html
+++ b/igv.html
@@ -30,30 +30,30 @@
     <script type="text/javascript" src="js/igv-canvas.js"></script>
     <script type="text/javascript" src="js/genome.js"></script>
     <script type="text/javascript" src="js/trackPanel.js"></script>
-    <script type="text/javascript" src="js/rulertrack.js"></script>
-    <script type="text/javascript" src="js/genetrack.js"></script>
+    <script type="text/javascript" src="js/rulerTrack.js"></script>
+    <script type="text/javascript" src="js/geneTrack.js"></script>
     <script type="text/javascript" src="js/bedSource.js"></script>
     <script type="text/javascript" src="js/igv-color.js"></script>
     <script type="text/javascript" src="js/igv-utils.js"></script>
     <script type="text/javascript" src="js/parseUtils.js"></script>
     <script type="text/javascript" src="js/fasta.js"></script>
-    <script type="text/javascript" src="js/sequencetrack.js"></script>
+    <script type="text/javascript" src="js/sequenceTrack.js"></script>
     <script type="text/javascript" src="js/wigSource.js"></script>
-    <script type="text/javascript" src="js/wigtrack.js"></script>
+    <script type="text/javascript" src="js/wigTrack.js"></script>
     <script type="text/javascript" src="js/dataloader.js"></script>
     <script type="text/javascript" src="js/igv-exts.js"></script>
     <script type="text/javascript" src="js/binary.js"></script>
-    <script type="text/javascript" src="js/gtex/eqtltrack.js"></script>
+    <script type="text/javascript" src="js/gtex/eqtlTrack.js"></script>
     <script type="text/javascript" src="js/coverageMap.js"></script>
     <script type="text/javascript" src="js/alignmentManager.js"></script>
     <script type="text/javascript" src="js/bamReader.js"></script>
     <script type="text/javascript" src="js/bamSource.js"></script>
-    <script type="text/javascript" src="js/bamtrack.js"></script>
+    <script type="text/javascript" src="js/bamTrack.js"></script>
     <script type="text/javascript" src="vendor/spin.js"></script>
-    <script type="text/javascript" src="js/intervaltree.js"></script>
+    <script type="text/javascript" src="js/intervalTree.js"></script>
 
     <script type="text/javascript" src="js/encode/encode.js"></script>
-    <script type="text/javascript" src="js/cursor/cursortrack.js"></script>
+    <script type="text/javascript" src="js/cursor/cursorTrack.js"></script>
     <script type="text/javascript" src="js/cursor/cursorModel.js"></script>
     <script type="text/javascript" src="js/cursor/cursor-ideogram.js"></script>
 


### PR DESCRIPTION
Trivial patch for hosting on Linux with case sensitive filenames. 
