### PR TITLE
Tracks added using the track height setting instead of the default.

### DIFF
--- a/js/gtex/gtex.js
+++ b/js/gtex/gtex.js
@@ -149,7 +149,8 @@ var igv = (function (igv) {
                                 sourceType: 'gtex',
                                 url: record.url,
                                 label: record.label,
-                                disableButtons: true
+                                disableButtons: true,
+                                height: browser.trackHeight
                             }
                         );
                     }


### PR DESCRIPTION
When EqtlTracks are created in the gtex version of the browser they match what is currently set as the heightBoxInput value instead of the default value.
