### PR TITLE
Ruler, Feature, and Sequence Tracks don't change height anymore.

### DIFF
--- a/js/gtex/gtex.js
+++ b/js/gtex/gtex.js
@@ -98,7 +98,16 @@ var igv = (function (igv) {
          * Change height of all tracks
          */
         heightBoxInput.onchange = function () {
-            igv.browser.setTrackHeight(heightBoxInput.value);
+            igv.browser.trackHeight = heightBoxInput.value;
+
+            igv.browser.trackViews.forEach(function (panel) {
+                if (panel.track instanceof igv.FeatureTrack ||
+                    panel.track instanceof igv.SequenceTrack ||
+                    panel.track instanceof igv.RulerTrack) {
+                    return;
+                }
+                panel.setTrackHeight(heightBoxInput.value);
+            });
         }
 
         $(trackHeightDiv).append(heightBoxInput);


### PR DESCRIPTION
Unrolled the igv.Browser.setTrackHeight function to create a gtex specific version when the heightBoxInput value changes.

This behavior is only in the gtex instantiation of the browser and is only attached to the heightBoxInput button element.
