### PR TITLE
Fixing minor bugs

### DIFF
--- a/js/bam/bamAlignment.js
+++ b/js/bam/bamAlignment.js
@@ -144,6 +144,8 @@ var igv = (function (igv) {
                 } else if (type === 'f') {
                     // TODO 'FIXME need floats';
                     value = 'floats not yet supported';
+                    tags[tag] = value;
+                    break;
                 } else if (type === 'Z') {
                     p += 3;
                     value = '';
@@ -158,7 +160,8 @@ var igv = (function (igv) {
                 } else {
                     //'Unknown type ' + type;
                     value = 'Error unknown type: ' + type;
-
+                    tags[tag] = value;
+                    break;
                 }
                 tags[tag] = value;
             }

--- a/js/igv-create.js
+++ b/js/igv-create.js
@@ -430,7 +430,7 @@ var igv = (function (igv) {
         }
         config.tracks.push({type: "sequence", order: -9999});
         config.showKaryo = config.showKaryo || false;
-        config.showNavigation = config.showNavigation || true;
+        config.showNavigation = config.showNavigation === undefined ? true : config.showNavigation;
         config.flanking = config.flanking === undefined ? 1000 : config.flanking;
 
     }


### PR DESCRIPTION
Proposed fix for two minor bugs:

1. Calling `decodeTags()` in `bamAlignment` could get into an infinite loop for unsupported types since `p` is not incremented. The fix just returns whatever tags have been decoded since there's no way to continue.

2. The way `true` default is applied on `config.showNavigation` makes it impossible to set a false value.