### PR TITLE
Feature label visibility

### DIFF
--- a/doc/events.html
+++ b/doc/events.html
@@ -75,6 +75,28 @@
                         <a href="../examples/events/custom-track-click.html">Popover Track Click Handling</a>
                     </td>
                 </tr>
+                <tr>
+                    <td>trackdrag</td>
+                    <td>
+                        <p>Fired whenever the user drags one of the tracks</p>
+                    </td>
+                    <td></td>
+                </tr>
+                <tr>
+                    <td>trackremoved</td>
+                    <td>
+                        <p>Fired whenever a track is removed from the viewer</p><br/>
+
+                        <strong>Arguments Passed to Handler Fn:</strong>
+                        <div class="well">
+                            <dl class="dl-horizontal">
+                                <dt>track</dt>
+                                <dd>{object} removed track</dd>
+                            </dl>
+                        </div>
+                    </td>
+                    <td></td>
+                </tr>
                 </tbody>
             </table>
         </div>

--- a/js/browser.js
+++ b/js/browser.js
@@ -245,7 +245,7 @@ var igv = (function (igv) {
         this.reorderTracks();
 
         trackView.resize();
-    }
+    };
 
     igv.Browser.prototype.reorderTracks = function () {
 
@@ -266,7 +266,7 @@ var igv = (function (igv) {
 
         });
 
-    }
+    };
 
     igv.Browser.prototype.removeTrack = function (track) {
 
@@ -280,11 +280,9 @@ var igv = (function (igv) {
         }
 
         if (trackPanelRemoved) {
-
-            this.trackViews.splice(this.trackViews.indexOf(trackPanelRemoved), 1);
-
+            this.trackViews.splice(i, 1);
             this.trackContainerDiv.removeChild(trackPanelRemoved.trackDiv);
-
+            this.fireEvent('trackremoved', [trackPanelRemoved.track]);
         }
 
     };
@@ -890,6 +888,7 @@ var igv = (function (igv) {
 
 
                     igv.browser.repaint();
+                    igv.browser.fireEvent('trackdrag');
                 }
 
                 lastMouseX = coords.x;

--- a/js/feature/featureTrack.js
+++ b/js/feature/featureTrack.js
@@ -527,7 +527,7 @@ var igv = (function (igv) {
      */
     function renderFusionJuncSpan(feature, bpStart, xScale, pixelHeight, ctx) {
 
-        var coord = calculateFeatureCoordinates(variant, bpStart, xScale),
+        var coord = calculateFeatureCoordinates(feature, bpStart, xScale),
             py = 5, h = 10; // defaults borrowed from renderFeature above
 
         var rowHeight = (this.displayMode === "EXPANDED") ? this.squishedCallHeight : this.expandedCallHeight;


### PR DESCRIPTION
Our app's users had the same feature request as is described in #185 so I figured it might be useful. 

These changes introduce the following:

- FeatureTrack's label rendering now accounts for the visible window when determining the label position. The label is now centered within the visible portion of feature.
- FeatureTrack's labels are repainted after track dragging stops - in my testing the dragging remains smooth.
- To enable this behavior I've added `trackdrag` and `trackremoved` events.

I did have one concern - do you think it's appropriate for FeatureTrack to reference its FeatureView's Tile object?