### PR TITLE
Vertical guide line implementation

### DIFF
--- a/css/igv.css
+++ b/css/igv.css
@@ -1390,6 +1390,16 @@ div.ui-dialog fieldset {
     height:100%;
 }
 
+.igv-vertical-line-div {
+    position: absolute;
+    border-left: 1px dashed #999;
+    top: 0;
+    bottom: 0;
+    right: 50%;
+    width: 1px;
+    z-index: 1;
+}
+
 .igv-content-canvas {
     position: absolute;
     width: 100%;

--- a/css/igv.css
+++ b/css/igv.css
@@ -1395,9 +1395,14 @@ div.ui-dialog fieldset {
     border-left: 1px dashed #999;
     top: 0;
     bottom: 0;
-    right: 50%;
+    left: 50%;
     width: 1px;
     z-index: 1;
+    user-select: none;
+    -moz-user-select: none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -o-user-select: none;
 }
 
 .igv-content-canvas {

--- a/js/browser.js
+++ b/js/browser.js
@@ -822,6 +822,7 @@ var igv = (function (igv) {
         var isRulerTrack = false,
             isMouseDown = false,
             isDragging = false,
+            stickyVerticalLine = igv.browser.config.showVerticalLine === 'sticky',
             lastMouseX = undefined,
             mouseDownX = undefined;
 
@@ -843,6 +844,17 @@ var igv = (function (igv) {
             lastMouseX = coords.x;
             mouseDownX = lastMouseX;
         });
+
+        // Vertical line should be bound within the track area and offset by 5 pixels so as
+        // not to interfere with mouse clicks.
+        if (stickyVerticalLine) {
+            $(trackContainerDiv).mousemove(function (e) {
+                var coords = igv.translateMouseCoordinates(e, trackContainerDiv),
+                    lineX = Math.max(50, coords.x - 5);
+                lineX = Math.min (igv.browser.trackContainerDiv.clientWidth - 65, lineX);
+                $(igv.browser.verticalLineDiv).css({left: lineX + 'px'});
+            });
+        }
 
         $(trackContainerDiv).mousemove(igv.throttle(function (e) {
 
@@ -904,9 +916,16 @@ var igv = (function (igv) {
 
         $(trackContainerDiv).mouseleave(mouseUpOrOut);
 
-        function mouseUpOrOut() {
+        function mouseUpOrOut(e) {
 
             if (isRulerTrack) {
+                return;
+            }
+
+            // Don't let vertical line interfere with dragging
+            if (igv.browser.verticalLineDiv
+                && e.toElement === igv.browser.verticalLineDiv
+                && e.type === 'mouseleave') {
                 return;
             }
 

--- a/js/igv-create.js
+++ b/js/igv-create.js
@@ -40,6 +40,7 @@ var igv = (function (igv) {
             contentDiv,
             headerDiv,
             trackContainerDiv,
+            verticalLineDiv,
             browser,
             rootDiv,
             controlDiv,
@@ -135,6 +136,11 @@ var igv = (function (igv) {
 
         contentDiv = $('<div class="igv-content-div">')[0];
         $(rootDiv).append(contentDiv);
+
+        if (config.showVerticalLine) {
+            verticalLineDiv = $('<div class="igv-vertical-line-div">')[0];
+            $(contentDiv).append(verticalLineDiv);
+        }
 
         headerDiv = $('<div>')[0];
         $(contentDiv).append(headerDiv);

--- a/js/igv-create.js
+++ b/js/igv-create.js
@@ -40,7 +40,6 @@ var igv = (function (igv) {
             contentDiv,
             headerDiv,
             trackContainerDiv,
-            verticalLineDiv,
             browser,
             rootDiv,
             controlDiv,
@@ -138,8 +137,8 @@ var igv = (function (igv) {
         $(rootDiv).append(contentDiv);
 
         if (config.showVerticalLine) {
-            verticalLineDiv = $('<div class="igv-vertical-line-div">')[0];
-            $(contentDiv).append(verticalLineDiv);
+            igv.browser.verticalLineDiv = $('<div class="igv-vertical-line-div">')[0];
+            $(contentDiv).append(igv.browser.verticalLineDiv);
         }
 
         headerDiv = $('<div>')[0];


### PR DESCRIPTION
The changelist introduces a centered vertical line that can be enabled using `showVerticalLine = true` browser config #137. Additionally, the line may be anchored to the cursor if `showVerticalLine = "sticky"` is set #131.

The line itself is just a border on an absolutely positioned DIV within the contentDiv. Its appearance can easily be styled using CSS and it avoids any additional canvas repainting. 