### PR TITLE
Expose Version Number Variable #220

### DIFF
--- a/js/igv-create.js
+++ b/js/igv-create.js
@@ -26,6 +26,7 @@
 var igv = (function (igv) {
 
     var igvjs_version = "beta";
+    igv.version = igvjs_version;
 
     /**
      * Create an igv.browser instance.  This object defines the public API for interacting with the genome browser.


### PR DESCRIPTION
This line would be enough to make the version number accessible from the "developer tools console" available in modern browsers.

This would be useful when debugging a website and trying to work out which version of IGV.js is being used.