### PR TITLE
bug fix about choosing first search result when multiple returned

### DIFF
--- a/js/browser.js
+++ b/js/browser.js
@@ -727,7 +727,7 @@ var igv = (function (igv) {
                         //alert('No feature found with name "' + feature + '"');
                         igv.presentAlert('No feature found with name "' + feature + '"');
                     }
-                    else if (results.length == 1) {
+                    else{
 
                         // Just take the first result for now
                         // TODO - merge results, or ask user to choose
@@ -739,9 +739,9 @@ var igv = (function (igv) {
                         type = r["featureType"] || r["type"];
                         handleSearchResult(feature, chr, start, end, type);
                     }
-                    else {
-                        presentSearchResults(results, searchConfig, feature);
-                    }
+                    //else {
+                    //    presentSearchResults(results, searchConfig, feature);
+                    //}
 
                     if (callback) callback();
                 });


### PR DESCRIPTION
The original design is to use the first one when multiple search results found. But there were something wrong with the logic implemented in the code. 

@jrobinso Is there any update about the function presentSearchResults to allow user to choose?

Another thing is, I customized some parts of jgv.js for cBioPortal usage. There are few features added. We are thinking to send pull request back to igv team. May I know should I send pull request back to master or other branch?