### PR TITLE
Support GCS paths for all track types. Fixes #271.

### DIFF
--- a/js/bam/bamReader.js
+++ b/js/bam/bamReader.js
@@ -33,13 +33,9 @@ var igv = (function (igv) {
 
         this.filter = config.filter || new igv.BamFilter();
 
-        this.bamPath = 'gcs' === config.sourceType ?
-            igv.translateGoogleCloudURL(config.url) :
-            config.url;
-        this.baiPath = 'gcs' === config.sourceType ?
-            igv.translateGoogleCloudURL(config.url + ".bai") :
-        config.url + ".bai"; // Todo - deal with Picard convention.  WHY DOES THERE HAVE TO BE 2?
-        this.baiPath = config.indexURL || this.baiPath; // If there is an indexURL provided, use it!
+        this.bamPath = config.url;
+        // Todo - deal with Picard convention.  WHY DOES THERE HAVE TO BE 2?
+        this.baiPath = config.indexURL || this.bamPath + ".bai"; // If there is an indexURL provided, use it!
         this.headPath = config.headURL || this.bamPath;
 
 

--- a/js/igvxhr.js
+++ b/js/igvxhr.js
@@ -48,6 +48,8 @@ var igvxhr = (function (igvxhr) {
                 withCredentials = options.withCredentials,
                 header_keys, key, value, i;
 
+            // Support for GCS paths.
+            url = url.startsWith("gs://") ? igv.translateGoogleCloudURL(url) : url;
 
             // Hack to prevent caching for google storage files.  Get weird net:err-cache errors otherwise
             if (range && url.includes("googleapis")) {


### PR DESCRIPTION
Let me know what you think. I believe this should be sufficient to allow any track type (references, variants, etc) to support gs:// paths.