### PR TITLE
get segment data in JSON format from API call

### DIFF
--- a/js/feature/featureFileReader.js
+++ b/js/feature/featureFileReader.js
@@ -105,16 +105,24 @@ var igv = (function (igv) {
             };
  
             function parseData(data) {
-                self.header = self.parser.parseHeader(data);
-                if (self.header instanceof String && self.header.startsWith("##gff-version 3")) {
-                    self.format = 'gff3';
+                if(self.config.json){
+                    fulfill(data);
+                }else{
+                    self.header = self.parser.parseHeader(data);
+                    if (self.header instanceof String && self.header.startsWith("##gff-version 3")) {
+                        self.format = 'gff3';
+                    }
+                    fulfill(self.parser.parseFeatures(data));   // <= PARSING DONE HERE
                 }
-                fulfill(self.parser.parseFeatures(data));   // <= PARSING DONE HERE
             };
 
 
             if (self.localFile) {
                 igvxhr.loadStringFromFile(self.localFile, options).then(parseData).catch(reject);
+            }
+            else if(self.config.json){
+                //this is customized for cBioPortal use case
+                igvxhr.loadJson(self.config.url, self.config).then(parseData).catch(reject);
             }
             else {
                 igvxhr.loadString(self.url, options).then(parseData).catch(reject);

--- a/js/igvxhr.js
+++ b/js/igvxhr.js
@@ -154,7 +154,7 @@ var igvxhr = (function (igvxhr) {
             }
         });
     }
-
+    
     igvxhr.loadArrayBuffer = function (url, options) {
 
         if (options === undefined) options = {};
@@ -166,7 +166,13 @@ var igvxhr = (function (igvxhr) {
 
         var method = options.method || (options.sendData ? "POST" : "GET");
 
-        if (method == "POST") options.contentType = "application/json";
+        if (method === "POST"){
+            if(options.json){
+                options.contentType = "application/x-www-form-urlencoded";
+            }else{
+                options.contentType = "application/json";
+            }
+        } 
 
         return new Promise(function (fulfill, reject) {
 


### PR DESCRIPTION
In cBioPortal, we get segment data from API calls, where the data is returned in JSON format. We added the functions below to support this feature, and in the hope that this feature could be useful for igv.js and be utilized for other similar usage.

It could be called easily by adding values in the initial options setting like below:
//json: flag to control using API call or not (true or false)
//url: the API url you want to access
//method: how you want to access your API
//parameters: parameters you want to pass in your API call 
options = {
                    ...
                    tracks: [
                        {
                           ...
                            type:"seg",
                            url: "http://www.cbioportal.org/beta/api-legacy/copynumbersegments",
                            json: true,
                            method: "POST",
                            sendData: 'cancerStudyId=coadread_tcga_pub&chromosome=12'
                        },
                        ...
                    ]
                };