### PR TITLE
sort sample by segment value at first initialization

### DIFF
--- a/js/igv-create.js
+++ b/js/igv-create.js
@@ -217,7 +217,13 @@ var igv = (function (igv) {
                         ss = browser.referenceFrame.start;
                         ee = ss + browser.trackViewportWidth() * browser.referenceFrame.bpPerPixel;
                         range = ss - ee;
-                        browser.loadTracksWithConfigList(config.tracks);
+                        var sortBy = [browser.referenceFrame.chr, ss, ee, "DESC"];
+                        if (config.tracks) {
+                            config.tracks.forEach(function(track){
+                                if(track.type === "seg")track.sortBy = sortBy;
+                            });
+                            browser.loadTracksWithConfigList(config.tracks);
+                        }
                     }, true);
 
                 } else {

--- a/js/trackView.js
+++ b/js/trackView.js
@@ -455,6 +455,13 @@ var igv = (function (igv) {
 
                         self.tile = new Tile(referenceFrame.chr, bpStart, bpEnd, referenceFrame.bpPerPixel, buffer);
                         self.paintImage();
+                        //In cBioPortal we have both gene track and CN segment track. Here we sort segment track after gene track is painted to make sure everything is already initialized for segment track when we call the sort function
+                        if(self.track.name === "Genes"){
+                            var segTracks = igv.browser.findTracks("type", "seg");
+                            segTracks.forEach(function (track) {
+                                track.sortSamples(track.config.sortBy[0], track.config.sortBy[1], track.config.sortBy[2], track.config.sortBy[3]);
+                            })
+                        }
                     }
                     else {
                         self.ctx.clearRect(0, 0, self.canvas.width, self.canvas.height);


### PR DESCRIPTION
We would like to have the segment viewer sorted decreasingly by the segment mean value at first load.  
To use this, we need to add specify [type: "seg"] in the segment track.