### PR TITLE
Made the toggle Karyotype button consistent with the other toggle buttons

### DIFF
--- a/css/igv.css
+++ b/css/igv.css
@@ -773,7 +773,8 @@ div.ui-dialog fieldset {
 
     position: relative;
     height: 20px;
-    width: 100px;
+    min-width: 100px;
+    text-transform: capitalize;
 
     float: right;
 

--- a/js/igv-create.js
+++ b/js/igv-create.js
@@ -337,22 +337,23 @@ var igv = (function (igv) {
             browser.karyoPanel = new igv.KaryoPanel(contentKaryo);
 
             $karyoPanelToggle = $('<div class="igv-nav-bar-toggle-button">');
+            $karyoPanelToggle.text("Karyotype");
 
             if (config.showKaryo === "hide") {
-                $karyoPanelToggle.text("Show Karyotype");
+                $karyoPanelToggle.toggleClass("igv-nav-bar-toggle-button-on")
                 $(contentKaryo).addClass("igv-karyo-hide");
             } else {
-                $karyoPanelToggle.text("Hide Karyotype");
+                $karyoPanelToggle.toggleClass("igv-nav-bar-toggle-button-off")
             }
 
             $karyoPanelToggle.click(function () {
                 var $karyo = $(".igv-karyo-div"),
                     hidden = $karyo.hasClass("igv-karyo-hide");
+                $karyoPanelToggle.toggleClass("igv-nav-bar-toggle-button-on");
+                $karyoPanelToggle.toggleClass("igv-nav-bar-toggle-button-off");
                 if (hidden) {
-                    $karyoPanelToggle.text("Hide Karyotype");
                     $karyo.removeClass("igv-karyo-hide");
                 } else {
-                    $karyoPanelToggle.text("Show Karyotype");
                     $karyo.addClass("igv-karyo-hide");
                 }
             });


### PR DESCRIPTION
I changed it from "Show Karyotype/Hide Karyotype" to just "Karyotype".

It now uses the CSS classes "igv-nav-bar-toggle-button-off" and "igv-nav-bar-toggle-button-on" to change colours when clicked.

I also tweaked the CSS for .igv-nav-bar-toggle-button a little bit, to provide more consistent capitalisation and button width.