### PR TITLE
Oauth support

### DIFF
--- a/js/bam/bamIndex.js
+++ b/js/bam/bamIndex.js
@@ -23,11 +23,7 @@ var igv = (function (igv) {
             var genome = igv.browser ? igv.browser.genome : null;
 
             igvxhr
-                .loadArrayBuffer(indexURL,
-                    {
-                        headers: config.headers,
-                        withCredentials: config.withCredentials
-                    })
+                .loadArrayBuffer(indexURL, igv.buildOptions(config))
                 .then(function (arrayBuffer) {
 
                     var indices = [],

--- a/js/bam/bamReader.js
+++ b/js/bam/bamReader.js
@@ -97,12 +97,8 @@ var igv = (function (igv) {
                                             fetchMax = c.maxv.block + 65000,   // Make sure we get the whole block.
                                             range = {start: fetchMin, size: fetchMax - fetchMin + 1};
 
-                                        igvxhr.loadArrayBuffer(self.bamPath,
-                                            {
-                                                headers: self.config.headers,
-                                                range: range,
-                                                withCredentials: self.config.withCredentials
-                                            }).then(function (compressed) {
+                                        igvxhr.loadArrayBuffer(self.bamPath, igv.buildOptions(self.config, {range: range}))
+                                            .then(function (compressed) {
 
                                             var ba = new Uint8Array(igv.unbgzf(compressed)); //new Uint8Array(igv.unbgzf(compressed)); //, c.maxv.block - c.minv.block + 1));
                                             decodeBamRecords(ba, c.minv.offset, alignmentContainer, bpStart, bpEnd, chrId, self.filter);
@@ -371,14 +367,8 @@ var igv = (function (igv) {
 
                 var len = index.firstAlignmentBlock + MAX_GZIP_BLOCK_SIZE;   // Insure we get the complete compressed block containing the header
 
-                igvxhr.loadArrayBuffer(self.bamPath,
-                    {
-                        headers: self.config.headers,
-
-                        range: {start: 0, size: len},
-
-                        withCredentials: self.config.withCredentials
-                    }).then(function (compressedBuffer) {
+                igvxhr.loadArrayBuffer(self.bamPath, igv.buildOptions(self.config, {range: {start: 0, size: len}})
+                    ).then(function (compressedBuffer) {
 
                     var unc = igv.unbgzf(compressedBuffer, len),
                         uncba = new Uint8Array(unc),

--- a/js/bam/bgzf.js
+++ b/js/bam/bgzf.js
@@ -71,13 +71,8 @@ var igv = (function (igv) {
 
         return new Promise(function (fulfill, reject) {
 
-            igvxhr.loadArrayBuffer(self.path,
-                {
-                    headers: self.config.headers,
-                    range: {start: self.filePosition, size: BLOCK_HEADER_LENGTH},
-                    withCredentials: self.config.withCredentials
-
-                }).then(function (arrayBuffer) {
+            igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: {start: self.filePosition, size: BLOCK_HEADER_LENGTH}}))
+                .then(function (arrayBuffer) {
 
                 var ba = new Uint8Array(arrayBuffer);
                 var xlen = (ba[11] << 8) | (ba[10]);
@@ -88,12 +83,8 @@ var igv = (function (igv) {
 
                 self.filePosition += BLOCK_HEADER_LENGTH;
 
-                igvxhr.loadArrayBuffer(self.path, {
-                    headers: self.config.headers,
-                    range: {start: self.filePosition, size: bsize},
-                    withCredentials: self.config.withCredentials
-
-                }).then(function (arrayBuffer) {
+                igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: {start: self.filePosition, size: bsize}}))
+                    .then(function (arrayBuffer) {
 
                     var unc = jszlib_inflate_buffer(arrayBuffer);
 

--- a/js/bigwig/bufferedReader.js
+++ b/js/bigwig/bufferedReader.js
@@ -69,12 +69,8 @@ var igv = (function (igv) {
                     loadRange = {start: requestedRange.start, size: bufferSize};
                 }
 
-                igvxhr.loadArrayBuffer(self.path,
-                    {
-                        headers: self.config.headers,
-                        range: loadRange,
-                        withCredentials: self.config.withCredentials
-                    }).then(function (arrayBuffer) {
+                igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: loadRange}))
+                    .then(function (arrayBuffer) {
                     self.data = arrayBuffer;
                     self.range = loadRange;
                     subbuffer(self, requestedRange, asUint8);

--- a/js/bigwig/bwReader.js
+++ b/js/bigwig/bwReader.js
@@ -67,12 +67,8 @@ var igv = (function (igv) {
         var self = this;
 
         return new Promise(function (fulfill, reject) {
-            igvxhr.loadArrayBuffer(self.path,
-                {
-                    headers: self.config.headers,
-                    range: {start: 0, size: BBFILE_HEADER_SIZE},
-                    withCredentials: self.config.withCredentials
-                }).then(function (data) {
+            igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: {start: 0, size: BBFILE_HEADER_SIZE}}))
+                .then(function (data) {
 
                 if (!data) return;
 
@@ -139,12 +135,8 @@ var igv = (function (igv) {
 
         return new Promise(function (fulfill, reject) {
 
-            igvxhr.loadArrayBuffer(self.path,
-                {
-                    headers: self.config.headers,
-                    range: {start: startOffset, size: (self.header.fullDataOffset - startOffset + 5)},
-                    withCredentials: self.config.withCredentials
-                }).then(function (data) {
+            igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: {start: startOffset, size: (self.header.fullDataOffset - startOffset + 5)}}))
+                .then(function (data) {
 
                 var nZooms = self.header.nZoomLevels,
                     binaryParser = new igv.BinaryParser(new DataView(data)),

--- a/js/feature/aneuSource.js
+++ b/js/feature/aneuSource.js
@@ -137,11 +137,7 @@ var igv = (function (igv) {
             success,
             features;
 
-        options = {
-            headers: self.config.headers,           // http headers, not file header
-            tokens: self.config.tokens,           // http headers, not file header
-            withCredentials: self.config.withCredentials
-        };
+        options = igv.buildOptions(self.config, {tokens: self.config.tokensc});
 
         success = function (data) {
             self.header = self.parser.parseHeader(data);

--- a/js/feature/aneuTrack.js
+++ b/js/feature/aneuTrack.js
@@ -127,12 +127,7 @@ var igv = (function (igv) {
                 }
             };
 
-            afterload = {
-                headers: self.config.headers, // http headers, not file header
-                tokens: self.config.tokens, // http headers, not file header
-                success: afterJsonLoaded,
-                withCredentials: self.config.withCredentials
-            };
+            afterload = igv.buildOptions(self.config, {tokens: self.config.tokens, success: afterJsonLoaded});
 
             igvxhr.loadString(self.config.url, afterload);
 
@@ -185,11 +180,7 @@ var igv = (function (igv) {
                     fulfill();
                 };
 
-                afterload = {
-                    headers: self.config.headers, // http headers, not file header
-                    tokens: self.config.tokens, // http headers, not file header
-                    withCredentials: self.config.withCredentials
-                };
+                afterload = igv.buildOptions(self.config, {tokens: self.config.tokens});
 
                 igvxhr.loadString(self.config.url, afterload).then(afterJsonLoaded);
 

--- a/js/feature/featureFileReader.js
+++ b/js/feature/featureFileReader.js
@@ -106,12 +106,7 @@ var igv = (function (igv) {
 
                             // Load the file header (not HTTP header) for an indexed file.
                             // TODO -- note this will fail if the file header is > 65kb in size
-                            options = {
-                                headers: self.config.headers,           // http headers, not file header
-                                bgz: index.tabix,
-                                range: {start: 0, size: 65000},
-                                withCredentials: self.config.withCredentials
-                            };
+                            options = igv.buildOptions(self.config, {bgz: index.tabix, range: {start: 0, size: 65000}});
 
                             success = function (data) {
                                 self.header = self.parser.parseHeader(data);
@@ -184,10 +179,7 @@ var igv = (function (igv) {
         var self = this;
 
         return new Promise(function (fullfill, reject) {
-            var options = {
-                headers: self.config.headers,           // http headers, not file header
-                withCredentials: self.config.withCredentials
-            };
+            var options = igv.buildOptions(self.config);
 
             function parseData(data) {
                 self.header = self.parser.parseHeader(data);
@@ -235,11 +227,12 @@ var igv = (function (igv) {
 
                         endPos = endPos = block.maxv.block + MAX_GZIP_BLOCK_SIZE;
 
-                        options = {
-                            headers: self.config.headers, // http headers, not file header
-                            range: {start: startPos, size: endPos - startPos + 1},
-                            withCredentials: self.config.withCredentials
-                        };
+                        options = igv.buildOptions(self.config, {
+                            range: {
+                                start: startPos,
+                                size: endPos - startPos + 1
+                            }
+                        });
 
                         success = function (data) {
 

--- a/js/feature/tribble.js
+++ b/js/feature/tribble.js
@@ -38,11 +38,7 @@ var igv = (function (igv) {
         return new Promise(function (fullfill) {
 
             igvxhr
-                .loadArrayBuffer(indexFile,
-                    {
-                        headers: config.headers,
-                        withCredentials: config.withCredentials
-                    })
+                .loadArrayBuffer(indexFile, igv.buildOptions(config))
                 .then(function (arrayBuffer) {
 
                     if (arrayBuffer) {

--- a/js/hic/hicReader.js
+++ b/js/hic/hicReader.js
@@ -49,12 +49,10 @@ var igv = (function (igv) {
 
         return new Promise(function (fulfill, reject) {
 
-            igvxhr.loadArrayBuffer(self.path,
-                {
-                    headers: self.config.headers,
-                    range: {start: 0, size: 64000},                     // TODO -- a guess, what if not enough ?
-                    withCredentials: self.config.withCredentials
-                }).then(function (data) {
+            igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {
+                    range: {start: 0, size: 64000} // TODO -- a guess, what if not enough ?
+                }))
+                .then(function (data) {
 
                 if (!data) {
                     fulfill(null);
@@ -117,12 +115,8 @@ var igv = (function (igv) {
 
         return new Promise(function (fulfill, reject) {
 
-            igvxhr.loadArrayBuffer(self.path,
-                {
-                    headers: self.config.headers,
-                    range: range,
-                    withCredentials: self.config.withCredentials
-                }).then(function (data) {
+            igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: range}))
+                .then(function (data) {
 
                 var key, pos, size;
 
@@ -228,12 +222,8 @@ var igv = (function (igv) {
 
         return new Promise(function (fulfill, reject) {
 
-            igvxhr.loadArrayBuffer(self.path,
-                {
-                    headers: self.config.headers,
-                    range: {start: idx.start, size: idx.size},
-                    withCredentials: self.config.withCredentials
-                }).then(function (data) {
+            igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: {start: idx.start, size: idx.size}}))
+                .then(function (data) {
 
                 if (!data) {
                     fulfill(null);
@@ -294,12 +284,8 @@ var igv = (function (igv) {
 
             return new Promise(function (fulfill, reject) {
 
-                igvxhr.loadArrayBuffer(self.path,
-                    {
-                        headers: self.config.headers,
-                        range: {start: idx.filePosition, size: idx.size},
-                        withCredentials: self.config.withCredentials
-                    }).then(function (data) {
+                igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: {start: idx.filePosition, size: idx.size}}))
+                    .then(function (data) {
 
                     if (!data) {
                         fulfill(null);

--- a/js/igv-utils.js
+++ b/js/igv-utils.js
@@ -464,6 +464,15 @@ var igv = (function (igv) {
         }
     };
 
+    igv.buildOptions = function(config, options) {
+        var defaultOptions = {
+            oauthToken: config.oauthToken || undefined,
+            headers: config.headers,
+            withCredentials: config.withCredentials
+        };
+
+        return _.extend(defaultOptions, options);
+    };
 
     return igv;
 

--- a/js/igvxhr.js
+++ b/js/igvxhr.js
@@ -43,13 +43,17 @@ var igvxhr = (function (igvxhr) {
                 responseType = options.responseType,
                 contentType = options.contentType,
                 mimeType = options.mimeType,
-                headers = options.headers,
+                headers = options.headers || {},
                 isSafari = navigator.vendor.indexOf("Apple") == 0 && /\sSafari\//.test(navigator.userAgent),
                 withCredentials = options.withCredentials,
                 header_keys, key, value, i;
 
             // Support for GCS paths.
             url = url.startsWith("gs://") ? igv.Google.translateGoogleCloudURL(url) : url;
+
+            if (options.token) {
+                headers["Authorization"] = 'Bearer ' + options.token;
+            }
 
             if (igv.Google.isGoogleURL(url)) {
 
@@ -171,7 +175,13 @@ var igvxhr = (function (igvxhr) {
 
         if (options === undefined) options = {};
         options.responseType = "arraybuffer";
-        return igvxhr.load(url, options);
+
+        return options.oauthToken ? options.oauthToken().then(applyOauthToken) : applyOauthToken();
+
+        function applyOauthToken(token) {
+            options.token = token;
+            return igvxhr.load(url, options);
+        }
     };
 
     igvxhr.loadJson = function (url, options) {

--- a/js/igvxhr.js
+++ b/js/igvxhr.js
@@ -34,148 +34,6 @@ var igvxhr = (function (igvxhr) {
 
         if (!options) options = {};
 
-        return new Promise(function (fullfill, reject) {
-
-            var xhr = new XMLHttpRequest(),
-                sendData = options.sendData || options.body,
-                method = options.method || (sendData ? "POST" : "GET"),
-                range = options.range,
-                responseType = options.responseType,
-                contentType = options.contentType,
-                mimeType = options.mimeType,
-                headers = options.headers || {},
-                isSafari = navigator.vendor.indexOf("Apple") == 0 && /\sSafari\//.test(navigator.userAgent),
-                withCredentials = options.withCredentials,
-                header_keys, key, value, i;
-
-            // Support for GCS paths.
-            url = url.startsWith("gs://") ? igv.Google.translateGoogleCloudURL(url) : url;
-
-            if (options.token) {
-                headers["Authorization"] = 'Bearer ' + options.token;
-            }
-
-            if (igv.Google.isGoogleURL(url)) {
-
-                url = igv.Google.addApiKey(url);
-
-                // Add google headers (e.g. oAuth)
-                headers = headers || {};
-                igv.Google.addGoogleHeaders(headers);
-
-            }
-
-            if (range) {
-                // Hack to prevent caching for byte-ranges. Attempt to fix net:err-cache errors in Chrome
-                url += url.includes("?") ? "&" : "?";
-                url += "someRandomSeed=" + Math.random().toString(36);
-            }
-
-            xhr.open(method, url);
-
-            if (range) {
-                var rangeEnd = range.size ? range.start + range.size - 1 : "";
-                xhr.setRequestHeader("Range", "bytes=" + range.start + "-" + rangeEnd);
-                //      xhr.setRequestHeader("Cache-Control", "no-cache");    <= This can cause CORS issues, disabled for now
-            }
-            if (contentType) {
-                xhr.setRequestHeader("Content-Type", contentType);
-            }
-            if (mimeType) {
-                xhr.overrideMimeType(mimeType);
-            }
-            if (responseType) {
-                xhr.responseType = responseType;
-            }
-            if (headers) {
-                header_keys = Object.keys(headers);
-                for (i = 0; i < header_keys.length; i++) {
-                    key = header_keys[i];
-                    value = headers[key];
-                    // console.log("Adding to header: " + key + "=" + value);
-                    xhr.setRequestHeader(key, value);
-                }
-            }
-
-            // NOTE: using withCredentials with servers that return "*" for access-allowed-origin will fail
-            if (withCredentials === true) {
-                xhr.withCredentials = true;
-            }
-
-            xhr.onload = function (event) {
-                // when the url points to a local file, the status is 0 but that is no error
-                if (xhr.status == 0 || (xhr.status >= 200 && xhr.status <= 300)) {
-
-                    if (range && xhr.status != 206) {
-                        handleError("ERROR: range-byte header was ignored for url: " + url);
-                    }
-                    else {
-                        fullfill(xhr.response);
-                    }
-                }
-                else {
-
-                    //
-                    if (xhr.status === 416) {
-                        //  Tried to read off the end of the file.   This shouldn't happen, but if it does return an
-                        handleError("Unsatisfiable range");
-                    }
-                    else {// TODO -- better error handling
-                        handleError(xhr.status);
-                    }
-
-                }
-
-            };
-
-            xhr.onerror = function (event) {
-
-                if (isCrossDomain(url) && url && !options.crossDomainRetried && igv.browser.crossDomainProxy &&
-                    url != igv.browser.crossDomainProxy) {
-
-                    options.sendData = "url=" + url;
-                    options.crossDomainRetried = true;
-
-                    igvxhr.load(igv.browser.crossDomainProxy, options).then(fullfill);
-                }
-                else {
-                    handleError("Error accessing resource: " + url + " Status: " + xhr.status);
-                }
-            }
-
-
-            xhr.ontimeout = function (event) {
-                handleError("Timed out");
-            };
-
-            xhr.onabort = function (event) {
-                console.log("Aborted");
-                reject(new igv.AbortLoad());
-            };
-
-            try {
-                xhr.send(sendData);
-            } catch (e) {
-                console.log(e);
-            }
-
-
-            function handleError(message) {
-                if (reject) {
-                    reject(new Error(message));
-                }
-                else {
-                    throw new Error(message);
-                }
-            }
-        });
-    };
-
-    igvxhr.loadArrayBuffer = function (url, options) {
-
-        if (options === undefined) options = {};
-        options.responseType = "arraybuffer";
-
         if (!options.oauthToken) {
             return applyOauthToken();
         }
@@ -195,8 +53,153 @@ var igvxhr = (function (igvxhr) {
                 options.token = token;
             }
 
-            return igvxhr.load(url, options);
+            return getLoadPromise(url, options);
         }
+
+        function getLoadPromise(url, options) {
+            return new Promise(function (fullfill, reject) {
+
+                var xhr = new XMLHttpRequest(),
+                    sendData = options.sendData || options.body,
+                    method = options.method || (sendData ? "POST" : "GET"),
+                    range = options.range,
+                    responseType = options.responseType,
+                    contentType = options.contentType,
+                    mimeType = options.mimeType,
+                    headers = options.headers || {},
+                    isSafari = navigator.vendor.indexOf("Apple") == 0 && /\sSafari\//.test(navigator.userAgent),
+                    withCredentials = options.withCredentials,
+                    header_keys, key, value, i;
+
+                // Support for GCS paths.
+                url = url.startsWith("gs://") ? igv.Google.translateGoogleCloudURL(url) : url;
+
+                if (options.token) {
+                    headers["Authorization"] = 'Bearer ' + options.token;
+                }
+
+                if (igv.Google.isGoogleURL(url)) {
+
+                    url = igv.Google.addApiKey(url);
+
+                    // Add google headers (e.g. oAuth)
+                    headers = headers || {};
+                    igv.Google.addGoogleHeaders(headers);
+
+                }
+
+                if (range) {
+                    // Hack to prevent caching for byte-ranges. Attempt to fix net:err-cache errors in Chrome
+                    url += url.includes("?") ? "&" : "?";
+                    url += "someRandomSeed=" + Math.random().toString(36);
+                }
+
+                xhr.open(method, url);
+
+                if (range) {
+                    var rangeEnd = range.size ? range.start + range.size - 1 : "";
+                    xhr.setRequestHeader("Range", "bytes=" + range.start + "-" + rangeEnd);
+                    //      xhr.setRequestHeader("Cache-Control", "no-cache");    <= This can cause CORS issues, disabled for now
+                }
+                if (contentType) {
+                    xhr.setRequestHeader("Content-Type", contentType);
+                }
+                if (mimeType) {
+                    xhr.overrideMimeType(mimeType);
+                }
+                if (responseType) {
+                    xhr.responseType = responseType;
+                }
+                if (headers) {
+                    header_keys = Object.keys(headers);
+                    for (i = 0; i < header_keys.length; i++) {
+                        key = header_keys[i];
+                        value = headers[key];
+                        // console.log("Adding to header: " + key + "=" + value);
+                        xhr.setRequestHeader(key, value);
+                    }
+                }
+
+                // NOTE: using withCredentials with servers that return "*" for access-allowed-origin will fail
+                if (withCredentials === true) {
+                    xhr.withCredentials = true;
+                }
+
+                xhr.onload = function (event) {
+                    // when the url points to a local file, the status is 0 but that is no error
+                    if (xhr.status == 0 || (xhr.status >= 200 && xhr.status <= 300)) {
+
+                        if (range && xhr.status != 206) {
+                            handleError("ERROR: range-byte header was ignored for url: " + url);
+                        }
+                        else {
+                            fullfill(xhr.response);
+                        }
+                    }
+                    else {
+
+                        //
+                        if (xhr.status === 416) {
+                            //  Tried to read off the end of the file.   This shouldn't happen, but if it does return an
+                            handleError("Unsatisfiable range");
+                        }
+                        else {// TODO -- better error handling
+                            handleError(xhr.status);
+                        }
+
+                    }
+
+                };
+
+                xhr.onerror = function (event) {
+
+                    if (isCrossDomain(url) && url && !options.crossDomainRetried && igv.browser.crossDomainProxy &&
+                        url != igv.browser.crossDomainProxy) {
+
+                        options.sendData = "url=" + url;
+                        options.crossDomainRetried = true;
+
+                        igvxhr.load(igv.browser.crossDomainProxy, options).then(fullfill);
+                    }
+                    else {
+                        handleError("Error accessing resource: " + url + " Status: " + xhr.status);
+                    }
+                }
+
+
+                xhr.ontimeout = function (event) {
+                    handleError("Timed out");
+                };
+
+                xhr.onabort = function (event) {
+                    console.log("Aborted");
+                    reject(new igv.AbortLoad());
+                };
+
+                try {
+                    xhr.send(sendData);
+                } catch (e) {
+                    console.log(e);
+                }
+
+
+                function handleError(message) {
+                    if (reject) {
+                        reject(new Error(message));
+                    }
+                    else {
+                        throw new Error(message);
+                    }
+                }
+            });
+        }
+    };
+
+    igvxhr.loadArrayBuffer = function (url, options) {
+
+        if (options === undefined) options = {};
+        options.responseType = "arraybuffer";
+        return igvxhr.load(url, options);
     };
 
     igvxhr.loadJson = function (url, options) {

--- a/js/igvxhr.js
+++ b/js/igvxhr.js
@@ -176,10 +176,25 @@ var igvxhr = (function (igvxhr) {
         if (options === undefined) options = {};
         options.responseType = "arraybuffer";
 
-        return options.oauthToken ? options.oauthToken().then(applyOauthToken) : applyOauthToken();
+        if (!options.oauthToken) {
+            return applyOauthToken();
+        }
+
+        var token = _.isFunction(options.oauthToken) ? options.oauthToken() : options.oauthToken;
+
+        if (token.then && _.isFunction(token.then)) {
+            return token.then(applyOauthToken);
+        }
+
+        return applyOauthToken(token);
+
+        ////////////
 
         function applyOauthToken(token) {
-            options.token = token;
+            if (token) {
+                options.token = token;
+            }
+
             return igvxhr.load(url, options);
         }
     };

--- a/js/tdf/tdfReader.js
+++ b/js/tdf/tdfReader.js
@@ -51,12 +51,8 @@ var igv = (function (igv) {
 
         return new Promise(function (fulfill, reject) {
 
-            igvxhr.loadArrayBuffer(self.path,
-                {
-                    headers: self.config.headers,
-                    range: {start: 0, size: 64000},
-                    withCredentials: self.config.withCredentials
-                }).then(function (data) {
+            igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: {start: 0, size: 64000}}))
+                .then(function (data) {
 
                 if (!data) {
                     reject("no data");
@@ -95,12 +91,8 @@ var igv = (function (igv) {
                 self.compressed = (self.flags & GZIP_FLAG) != 0;
 
                 // Now read index
-                igvxhr.loadArrayBuffer(self.path,
-                    {
-                        headers: self.config.headers,
-                        range: {start: self.indexPos, size: self.indexSize},
-                        withCredentials: self.config.withCredentials
-                    }).then(function (data) {
+                igvxhr.loadArrayBuffer(self.path,igv.buildOptions(self.config, {range: {start: self.indexPos, size: self.indexSize}}))
+                    .then(function (data) {
 
 
                     if (!data) {
@@ -165,12 +157,8 @@ var igv = (function (igv) {
                 else {
 
 
-                    igvxhr.loadArrayBuffer(self.path,
-                        {
-                            headers: self.config.headers,
-                            range: {start: indexEntry.position, size: indexEntry.size},
-                            withCredentials: self.config.withCredentials
-                        }).then(function (data) {
+                    igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: {start: indexEntry.position, size: indexEntry.size}}))
+                        .then(function (data) {
 
                         if (!data) {
                             reject("no data");
@@ -271,12 +259,8 @@ var igv = (function (igv) {
                 else {
 
 
-                    igvxhr.loadArrayBuffer(self.path,
-                        {
-                            headers: self.config.headers,
-                            range: {start: indexEntry.position, size: indexEntry.size},
-                            withCredentials: self.config.withCredentials
-                        }).then(function (data) {
+                    igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: {start: indexEntry.position, size: indexEntry.size}}))
+                        .then(function (data) {
 
                         if (!data) {
                             reject("no data");
@@ -429,12 +413,8 @@ var igv = (function (igv) {
 
         return new Promise(function (fulfill, reject) {
 
-            igvxhr.loadArrayBuffer(self.path,
-                {
-                    headers: self.config.headers,
-                    range: {start: indexEntry.position, size: indexEntry.size},
-                    withCredentials: self.config.withCredentials
-                }).then(function (data) {
+            igvxhr.loadArrayBuffer(self.path, igv.buildOptions(self.config, {range: {start: indexEntry.position, size: indexEntry.size}}))
+                .then(function (data) {
 
                 if (!data) {
                     reject("no data");


### PR DESCRIPTION
The wiki page could look like this:

# OAuth support

Files provided behind an OAuth secured endpoint need a bearer access token to be accessed. The bearer access token can be provided within the track definition in several ways:
1. As a function returning the token string itself or a promise:
```js
{
  "name": "Phase 3 WGS variants",
  "format": "vcf",
  "url": "https://s3.amazonaws.com/1000genomes/release/20130502/ALL.wgs.phase3_shapeit2_mvncall_integrated_v5b.20130502.sites.vcf.gz",
  "indexURL":  "https://s3.amazonaws.com/1000genomes/release/20130502/ALL.wgs.phase3_shapeit2_mvncall_integrated_v5b.20130502.sites.vcf.gz.tbi",
  "type": "variant",
  "oauthToken": myOauthTokenFn
}
```
2. As a string or a promise:
```js
{
  "name": "Phase 3 WGS variants",
  "format": "vcf",
  "url": "https://s3.amazonaws.com/1000genomes/release/20130502/ALL.wgs.phase3_shapeit2_mvncall_integrated_v5b.20130502.sites.vcf.gz",
  "indexURL":  "https://s3.amazonaws.com/1000genomes/release/20130502/ALL.wgs.phase3_shapeit2_mvncall_integrated_v5b.20130502.sites.vcf.gz.tbi",
  "type": "variant",
  "oauthToken": "F0jh9korTyzd9kaZqZ0SzjKZuS3ut0i4P46Lc52m2JYHiLIcqzFAumpyxshU9mMQ13gJHtxD2fy"
}
```

If the token is provided it's sent in the "Authorization" header as a "Bearer" token for each request.

The function approach (1.) is preferred because it's a safe way how to provide up-to-date token to the igv.js browser all the time. The value approach (2.) will work only for a life of the token and the browser would need to be refreshed after the token is expired.

The function approach works out of the box with Angular.js promises. The `myOauthTokenFn` could look like this:
```js
function myOauthTokenFn() {
  return $http.get(myOauthEndpointURL).then(parseAccessToken);      
}
```

Please be aware the token definition is shared between all the files within a single track. If the main files and index files are hosted in different locations, this approach may not work.