### PR TITLE
bug with squished/expanded click/track_resize

### DIFF
--- a/js/feature/featureTrack.js
+++ b/js/feature/featureTrack.js
@@ -132,7 +132,7 @@ var igv = (function (igv) {
 
                 });
             }
-            return Math.max(this.variantHeight, (maxRow + 1) * (this.displayMode === "SQUISHED" ? this.expandedCallHeight : this.squishedCallHeight));
+            return Math.max(this.variantHeight, (maxRow + 1) * (this.displayMode === "SQUISHED" ? this.squishedCallHeight : this.expandedCallHeight));
 
         }
 
@@ -202,7 +202,7 @@ var igv = (function (igv) {
                 row;
 
             if (this.displayMode != "COLLAPSED") {
-                row = (Math.floor)(this.displayMode === "SQUISHED" ? yOffset / this.expandedCallHeight : yOffset / this.squishedCallHeight);
+                row = (Math.floor)(this.displayMode === "SQUISHED" ? yOffset / this.squishedCallHeight : yOffset / this.expandedCallHeight);
             }
 
             if (featureList && featureList.length > 0) {


### PR DESCRIPTION
Feature clicking had a bug where it was using expandedCallHeight for tracks in SQUISHED mode, and squishedCallHeight for tracks in EXPANDED mode (would cause wrong feature popup to be displayed)

Same issue for the track_height resizing when toggling between EXPANDED and SQUISHED, was using wrong callHeight variable.