### PR TITLE
Refactor Track Creation to trackCore.js

### DIFF
--- a/dev/igv-dev.html
+++ b/dev/igv-dev.html
@@ -539,7 +539,8 @@
                 {
                     sourceType: 'gcs',
                     type: 'bam',
-                    url: '../test/data/bam/four.reads.bam', // 'gs://genomics-public-data/platinum-genomes/bam/NA12877_S1.bam',
+//                    url: '../test/data/bam/four.reads.bam',,
+                    url: 'gs://genomics-public-data/platinum-genomes/bam/NA12877_S1.bam',
                     height: 500,
                     autoHeight: false,
                     viewAsPairs: false,

--- a/js/browser.js
+++ b/js/browser.js
@@ -211,10 +211,9 @@ var igv = (function (igv) {
             settings,
             property,
             newTrack,
-            featureSource,
-            nm;
+            featureSource;
 
-        inferTypes(config);
+        igv.inferTrackTypes(config);
 
         // Set defaults if specified
         if (this.trackDefaults && config.type) {
@@ -228,7 +227,7 @@ var igv = (function (igv) {
             }
         }
 
-        newTrack = createTrackWithConfiguration(config);
+        newTrack = igv.createTrackWithConfiguration(config);
 
         if (undefined === newTrack) {
             igv.presentAlert("Unknown file type: " + config.url);
@@ -252,189 +251,6 @@ var igv = (function (igv) {
         }
 
         return newTrack;
-
-        function createTrackWithConfiguration(conf) {
-
-            var type = (undefined === conf.type) ? 'unknown_type' : conf.type.toLowerCase();
-
-            switch (type) {
-                case "gwas":
-                    return new igv.GWASTrack(conf);
-                    break;
-
-                case "annotation":
-                case "genes":
-                case "fusionjuncspan":
-                    return new igv.FeatureTrack(conf);
-                    break;
-
-                case "variant":
-                    return new igv.VariantTrack(conf);
-                    break;
-
-                case "alignment":
-                    return new igv.BAMTrack(conf, featureSource);
-                    break;
-
-                case "data":  // deprecated
-                case "wig":
-                    return new igv.WIGTrack(conf);
-                    break;
-
-                case "sequence":
-                    return new igv.SequenceTrack(conf);
-                    break;
-
-                case "eqtl":
-                    return new igv.EqtlTrack(conf);
-                    break;
-
-                case "seg":
-                    return new igv.SegTrack(conf);
-                    break;
-
-                case "aneu":
-                    return new igv.AneuTrack(conf);
-                    break;
-
-                default:
-                    return undefined;
-            }
-
-        }
-
-        /**
-         * Infer properties format and track type from legacy "config.type" property
-         *
-         * @param config
-         */
-        function inferTypes(config) {
-
-            function translateDeprecatedTypes(config) {
-
-                if (config.featureType) {  // Translate deprecated "feature" type
-                    config.type = config.type || config.featureType;
-                    config.featureType = undefined;
-                }
-
-                if ("bed" === config.type) {
-                    config.type = "annotation";
-                    config.format = config.format || "bed";
-
-                }
-
-                else if ("bam" === config.type) {
-                    config.type = "alignment";
-                    config.format = "bam"
-                }
-
-                else if ("vcf" === config.type) {
-                    config.type = "variant";
-                    config.format = "vcf"
-                }
-
-                else if ("t2d" === config.type) {
-                    config.type = "gwas";
-                }
-
-                else if ("FusionJuncSpan" === config.type) {
-                    config.format = "fusionjuncspan";
-                }
-            }
-
-            function inferFileFormat(config) {
-
-                var path,
-                    fn,
-                    idx,
-                    ext;
-
-                if (config.format) {
-                    config.format = config.format.toLowerCase();
-                    return;
-                }
-
-                path = igv.isFilePath(config.url) ? config.url.name : config.url;
-                fn = path.toLowerCase();
-
-                //Strip parameters -- handle local files later
-                idx = fn.indexOf("?");
-                if (idx > 0) {
-                    fn = fn.substr(0, idx);
-                }
-
-                //Strip aux extensions .gz, .tab, and .txt
-                if (fn.endsWith(".gz")) {
-                    fn = fn.substr(0, fn.length - 3);
-                } else if (fn.endsWith(".txt") || fn.endsWith(".tab")) {
-                    fn = fn.substr(0, fn.length - 4);
-                }
-
-
-                idx = fn.lastIndexOf(".");
-                ext = idx < 0 ? fn : fn.substr(idx + 1);
-
-                switch (ext.toLowerCase()) {
-
-                    case "bw":
-                        config.format = "bigwig";
-                        break;
-                    case "bb":
-                        config.format = "bigbed";
-
-                    default:
-                        if (knownFileExtensions.has(ext)) {
-                            config.format = ext;
-                        }
-                }
-            }
-
-            function inferTrackType(config) {
-
-                if (config.type) return;
-
-                if (config.format !== undefined) {
-                    switch (config.format.toLowerCase()) {
-                        case "bw":
-                        case "bigwig":
-                        case "wig":
-                        case "bedgraph":
-                        case "tdf":
-                            config.type = "wig";
-                            break;
-                        case "vcf":
-                            config.type = "variant";
-                            break;
-                        case "seg":
-                            config.type = "seg";
-                            break;
-                        case "bam":
-                            config.type = "alignment";
-                            break;
-                        default:
-                            config.type = "annotation";
-                    }
-                }
-            }
-
-            translateDeprecatedTypes(config);
-
-            if (undefined === config.sourceType && config.url) {
-                config.sourceType = "file";
-            }
-
-            if ("file" === config.sourceType) {
-                if (undefined === config.format) {
-                    inferFileFormat(config);
-                }
-            }
-
-            if (undefined === config.type) {
-                inferTrackType(config);
-            }
-
-
-        }
 
     };
 

--- a/js/trackCore.js
+++ b/js/trackCore.js
@@ -28,6 +28,187 @@
 
 var igv = (function (igv) {
 
+    var knownFileExtensions = new Set(["narrowpeak", "broadpeak", "peaks", "bedgraph", "wig", "gff3", "gff",
+        "gtf", "aneu", "fusionjuncspan", "refflat", "seg", "bed", "vcf", "bb", "bigbed", "bw", "bigwig", "bam", "tdf"]);
+
+    igv.createTrackWithConfiguration = function(conf) {
+
+        var type = (undefined === conf.type) ? 'unknown_type' : conf.type.toLowerCase();
+
+        switch (type) {
+            case "gwas":
+                return new igv.GWASTrack(conf);
+                break;
+
+            case "annotation":
+            case "genes":
+            case "fusionjuncspan":
+                return new igv.FeatureTrack(conf);
+                break;
+
+            case "variant":
+                return new igv.VariantTrack(conf);
+                break;
+
+            case "alignment":
+                return new igv.BAMTrack(conf);
+                break;
+
+            case "data":  // deprecated
+            case "wig":
+                return new igv.WIGTrack(conf);
+                break;
+
+            case "sequence":
+                return new igv.SequenceTrack(conf);
+                break;
+
+            case "eqtl":
+                return new igv.EqtlTrack(conf);
+                break;
+
+            case "seg":
+                return new igv.SegTrack(conf);
+                break;
+
+            case "aneu":
+                return new igv.AneuTrack(conf);
+                break;
+
+            default:
+                return undefined;
+        }
+
+    };
+
+    igv.inferTrackTypes = function(config) {
+
+        function translateDeprecatedTypes(config) {
+
+            if (config.featureType) {  // Translate deprecated "feature" type
+                config.type = config.type || config.featureType;
+                config.featureType = undefined;
+            }
+
+            if ("bed" === config.type) {
+                config.type = "annotation";
+                config.format = config.format || "bed";
+
+            }
+
+            else if ("bam" === config.type) {
+                config.type = "alignment";
+                config.format = "bam"
+            }
+
+            else if ("vcf" === config.type) {
+                config.type = "variant";
+                config.format = "vcf"
+            }
+
+            else if ("t2d" === config.type) {
+                config.type = "gwas";
+            }
+
+            else if ("FusionJuncSpan" === config.type) {
+                config.format = "fusionjuncspan";
+            }
+        }
+
+        function inferFileFormat(config) {
+
+            var path,
+                fn,
+                idx,
+                ext;
+
+            if (config.format) {
+                config.format = config.format.toLowerCase();
+                return;
+            }
+
+            path = igv.isFilePath(config.url) ? config.url.name : config.url;
+            fn = path.toLowerCase();
+
+            //Strip parameters -- handle local files later
+            idx = fn.indexOf("?");
+            if (idx > 0) {
+                fn = fn.substr(0, idx);
+            }
+
+            //Strip aux extensions .gz, .tab, and .txt
+            if (fn.endsWith(".gz")) {
+                fn = fn.substr(0, fn.length - 3);
+            } else if (fn.endsWith(".txt") || fn.endsWith(".tab")) {
+                fn = fn.substr(0, fn.length - 4);
+            }
+
+
+            idx = fn.lastIndexOf(".");
+            ext = idx < 0 ? fn : fn.substr(idx + 1);
+
+            switch (ext.toLowerCase()) {
+
+                case "bw":
+                    config.format = "bigwig";
+                    break;
+                case "bb":
+                    config.format = "bigbed";
+
+                default:
+                    if (knownFileExtensions.has(ext)) {
+                        config.format = ext;
+                    }
+            }
+        }
+
+        function inferTrackType(config) {
+
+            if (config.type) return;
+
+            if (config.format !== undefined) {
+                switch (config.format.toLowerCase()) {
+                    case "bw":
+                    case "bigwig":
+                    case "wig":
+                    case "bedgraph":
+                    case "tdf":
+                        config.type = "wig";
+                        break;
+                    case "vcf":
+                        config.type = "variant";
+                        break;
+                    case "seg":
+                        config.type = "seg";
+                        break;
+                    case "bam":
+                        config.type = "alignment";
+                        break;
+                    default:
+                        config.type = "annotation";
+                }
+            }
+        }
+
+        translateDeprecatedTypes(config);
+
+        if (undefined === config.sourceType && config.url) {
+            config.sourceType = "file";
+        }
+
+        if ("file" === config.sourceType) {
+            if (undefined === config.format) {
+                inferFileFormat(config);
+            }
+        }
+
+        if (undefined === config.type) {
+            inferTrackType(config);
+        }
+
+
+    };
+
     /**
      * Set defaults for properties applicable to all tracks.
      * Insure required "config" properties are set.
@@ -68,7 +249,10 @@ var igv = (function (igv) {
             track.visibilityWindow = config.visibilityWindow;
         }
 
-        if(track.type === undefined) track.type = config.type;
+        if(track.type === undefined) {
+            track.type = config.type;
+        }
+
     };
 
     igv.setTrackLabel = function (track, label) {


### PR DESCRIPTION
Refactor track creation to `trackCore.js` to support JuiceboxJS.
