### PR TITLE
arrayToCommaString bug

### DIFF
--- a/js/variant/variant.js
+++ b/js/variant/variant.js
@@ -242,7 +242,7 @@ var igv = (function (igv) {
         if (array.length > 0)
             str = array[0];
         for (i = 1; i < array.length; i++) {
-            str += ", " + array[1];
+            str += ", " + array[i];
         }
         return str;
 

--- a/js/variant/variant.js
+++ b/js/variant/variant.js
@@ -237,7 +237,7 @@ var igv = (function (igv) {
     };
 
     function arrayToCommaString(array) {
-        if (!array) return;
+        if (!array instanceof Array) return '';
         return array.join(',');
 
     }

--- a/js/variant/variant.js
+++ b/js/variant/variant.js
@@ -237,7 +237,7 @@ var igv = (function (igv) {
     };
 
     function arrayToCommaString(array) {
-        if (!array instanceof Array) return '';
+        if (!(array instanceof Array)) return '';
         return array.join(',');
 
     }

--- a/js/variant/variant.js
+++ b/js/variant/variant.js
@@ -238,13 +238,7 @@ var igv = (function (igv) {
 
     function arrayToCommaString(array) {
         if (!array) return;
-        var str = '', i;
-        if (array.length > 0)
-            str = array[0];
-        for (i = 1; i < array.length; i++) {
-            str += ", " + array[i];
-        }
-        return str;
+        return array.join(',');
 
     }
 


### PR DESCRIPTION
This function can be simply replaced by `join()`,  by the way, **`1` was used as `i`**.