### PR TITLE
support CIGARs with >65535 operators

### DIFF
--- a/js/bam/bamUtils.js
+++ b/js/bam/bamUtils.js
@@ -250,7 +250,7 @@ var igv = (function (igv) {
                 alignment.fragmentLength = tlen;
                 alignment.mq = mq;
 
-                bam_tag2cigar(ba, BlockEnd, p, lseq, alignment, cigarArray);
+                igv.BamUtils.bam_tag2cigar(ba, BlockEnd, p, lseq, alignment, cigarArray);
 
                 if (alignment.start + alignment.lengthOnRef < min) {
                     offset = blockEnd;


### PR DESCRIPTION
The current BAM spec doesn't support a cigar with >65535 operators. However, aligning ultra-long nanopore reads occasionally produces such alignments that can't be directly encoded in BAM. It will fail *all* released SAM=>BAM converters so far. [Minimap2](https://github.com/lh3/minimap2) has an option "-L" that moves a long cigar to a tag. A modified BAM reader can move the real cigar in the tag back to the right place on reading. This simple solution seamlessly solves the long-cigar issue. Users and most developers won't even notice this change.

This PR adds the long cigar support to igv.js. A working example can be found [at this page](http://lh3lh3.users.sourceforge.net/data/cigar-64k/igv-js-test/bam-lh3.html). It points to a read aligned with >72000 operators and displays it correctly. You can also find the example BAM [in its parent directory](http://lh3lh3.users.sourceforge.net/data/cigar-64k/).