### PR TITLE
 Set headers for GA4GH GET requests

### DIFF
--- a/js/ga4gh/ga4ghHelper.js
+++ b/js/ga4gh/ga4ghHelper.js
@@ -32,6 +32,7 @@ var igv = (function (igv) {
     igv.ga4ghGet = function (options) {
 
         var url = options.url + "/" + options.entity + "/" + options.entityId;
+        options.headers = ga4ghHeaders();
 
         return igv.xhr.loadJson(url, options);      // Returns a promise
     }


### PR DESCRIPTION
I was using this against a local GA4GH service and noticed that the Authorization header was not getting set on GET requests.   I only found some old GA4GH tests that may cover this change.   I was not sure if there was some other test I should verify here, but the change is pretty minor.   