### PR TITLE
Only reinitialize canvas when resizing (#545)

### DIFF
--- a/js/ideogram.js
+++ b/js/ideogram.js
@@ -279,7 +279,7 @@ var igv = (function (igv) {
 
             var shim = 1,
               ideogramTop = 0,
-              shim2 = 2;
+              shim2 = 0.5;
 
             if (!igv.browser.genome) {
                 return;
@@ -316,16 +316,16 @@ var igv = (function (igv) {
 
                             if (cytoband.name.charAt(0) === 'p') {
                                 xC[0] = start;
-                                yC[0] = ideogramHeight + ideogramTop;
+                                yC[0] = ideogramHeight + ideogramTop - shim;
                                 xC[1] = start;
-                                yC[1] = ideogramTop;
+                                yC[1] = ideogramTop + shim;
                                 xC[2] = end;
                                 yC[2] = center;
                             } else {
                                 xC[0] = end;
-                                yC[0] = ideogramHeight + ideogramTop;
+                                yC[0] = ideogramHeight + ideogramTop - shim;
                                 xC[1] = end;
-                                yC[1] = ideogramTop;
+                                yC[1] = ideogramTop + shim;
                                 xC[2] = start;
                                 yC[2] = center;
                             }
@@ -341,18 +341,18 @@ var igv = (function (igv) {
                             // fillRect: function (ctx, x, y, w, h, properties)
 
                             // bufferCtx.fillRect(start, ideogramTop, (end - start), ideogramHeight);
-                            bufferCtx.fillRect(start, ideogramTop, (end - start), ideogramHeight);
+                            bufferCtx.fillRect(start, ideogramTop + shim, (end - start), ideogramHeight - 2*shim);
                         }
                     }
                 }
             }
-            bufferCtx.strokeStyle = "rgba(0, 0, 0, 0.5)";
-            bufferCtx.lineWidth = 2;
+            bufferCtx.strokeStyle = "black";
+            bufferCtx.lineWidth = 1;
 
             // roundRect(x, y, width, height, radius, fill, stroke)
 
             // bufferCtx.roundRect(0, ideogramTop, ideogramWidth, ideogramHeight, ideogramHeight / 2, 0, 1);
-            bufferCtx.roundRect(shim, shim + ideogramTop, ideogramWidth - 2 * shim, ideogramHeight - 2*shim, (ideogramHeight - 2*shim)/2, 0, 1);
+            bufferCtx.roundRect(shim2, shim2 + ideogramTop, ideogramWidth - 2 * shim2, ideogramHeight - 2*shim2, (ideogramHeight - 2*shim2)/2, 0, 1);
             lastPX = end;
         }
 

--- a/js/ideogram.js
+++ b/js/ideogram.js
@@ -77,7 +77,7 @@ var igv = (function (igv) {
         _.each(this.panels, function(panel, index) {
             var genomicState = igv.browser.genomicStateList[ index ];
             panel.$ideogram.width(Math.floor(viewportContainerWidth/igv.browser.genomicStateList.length));
-            panel.$canvas.attr('width', panel.$ideogram.width());
+            setupCanvasSize(panel);
             panel.ideograms = {};
         });
 
@@ -123,6 +123,18 @@ var igv = (function (igv) {
         repaintPanel( this.panels[ index ] );
     };
 
+    function setupCanvasSize(panel) {
+        var canvas = panel.$canvas.get(0);
+        var w = +panel.$ideogram.width();
+        var h = +panel.$ideogram.height();
+        canvas.style.width = w;
+        canvas.style.height = h;
+        canvas.width = devicePixelRatio * w;
+        canvas.height = devicePixelRatio * h;
+        panel.ctx = canvas.getContext("2d");
+        panel.ctx.scale(devicePixelRatio, devicePixelRatio);
+    }
+
     function panelWithGenomicState($parent, genomicState, $previousPanelOrUndefined) {
 
         var viewportContainerWidth,
@@ -155,16 +167,7 @@ var igv = (function (igv) {
         //panel.$canvas.attr('height', panel.$ideogram.height());
         //panel.ctx = panel.$canvas.get(0).getContext("2d");
 
-        var canvas = panel.$canvas.get(0);
-        var w = +panel.$ideogram.width();
-        var h = +panel.$ideogram.height();
-        canvas.style.width = w;
-        canvas.style.height = h;
-        canvas.width = devicePixelRatio * w;
-        canvas.height = devicePixelRatio * h;
-        panel.ctx = canvas.getContext("2d");
-        panel.ctx.scale(devicePixelRatio, devicePixelRatio);
-
+        setupCanvasSize(panel);
         panel.ideograms = {};
 
         panel.$ideogram.on('click', function (e) {
@@ -203,12 +206,9 @@ var igv = (function (igv) {
             stainColors = [];
             canvasWidth = panel.$canvas.width();
             canvasHeight = panel.$canvas.height();
-            panel.$canvas.get(0).width = devicePixelRatio * canvasWidth;
-            panel.$canvas.get(0).height = devicePixelRatio * canvasHeight;
-            panel.ctx.scale(devicePixelRatio, devicePixelRatio);
 
             panel.ctx.clearRect(0, 0, canvasWidth, canvasHeight);
-            
+
             if(referenceFrame.chrName.toLowerCase() === "all") {
                 return;
             }

--- a/js/ideogram.js
+++ b/js/ideogram.js
@@ -345,7 +345,8 @@ var igv = (function (igv) {
                     }
                 }
             }
-            bufferCtx.strokeStyle = "black";
+            bufferCtx.strokeStyle = "rgba(0, 0, 0, 0.5)";
+            bufferCtx.lineWidth = 2;
 
             // roundRect(x, y, width, height, radius, fill, stroke)
 

--- a/js/ideogram.js
+++ b/js/ideogram.js
@@ -278,7 +278,8 @@ var igv = (function (igv) {
         function drawIdeogram(bufferCtx, ideogramWidth, ideogramHeight) {
 
             var shim = 1,
-                ideogramTop = 0;
+              ideogramTop = 0,
+              shim2 = 2;
 
             if (!igv.browser.genome) {
                 return;
@@ -340,7 +341,7 @@ var igv = (function (igv) {
                             // fillRect: function (ctx, x, y, w, h, properties)
 
                             // bufferCtx.fillRect(start, ideogramTop, (end - start), ideogramHeight);
-                            bufferCtx.fillRect(start, shim + ideogramTop, (end - start), ideogramHeight - 2*shim);
+                            bufferCtx.fillRect(start, ideogramTop, (end - start), ideogramHeight);
                         }
                     }
                 }


### PR DESCRIPTION
I think it is better to do expensive operations only when you really must. My assumption is that changing canvas backing store size means the browser has to reallocate the entire canvas buffer, which really should be done only on resizes...