### PR TITLE
Provide easily usable ES6 export, improve package metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,33 @@
 {
-  "name": "IGV",
-  "version": "0.0.1",
+  "name": "igv",
+  "version": "2.0.0-rc5",
+  "description": "Embeddable genomic visualization component based on the Integrative Genomics Viewer",
+  "main": "dist/igv.esm.js",
+  "files": ["dist/**"],
+  "scripts": {
+    "prepublishOnly": "grunt"
+  },
+  "author": {
+    "name": "Jim Robinson",
+    "email": "igv-team@broadinstitute.org",
+    "url": "https://igv.org"
+  },
+  "bugs": {
+    "url": "https://github.com/igvteam/igv.js/issues"
+  },
+  "bundleDependencies": false,
+  "deprecated": false,
+  "homepage": "https://igv.org",
+  "keywords": [
+    "IGV",
+    "genomics",
+    "visualization"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/igvteam/igv.js.git"
+  },
   "devDependencies": {
     "grunt": "1.0.3",
     "grunt-contrib-concat": "1.0.1",


### PR DESCRIPTION
This enables including igv.js using ES6 `import` as done in modern React, Angular and Vue, while retaining support for AMD `require` and plain `script` tags, as discussed in #701.  

It also adds `scripts` and `files` properties to package.json to build igv.js artifacts before publishing to NPM, and to strip other files from the package.  And it puts metadata previously only visible in the published NPM package into source control, to be more open source and in line with mainstream JS conventions.

See the following for examples of various ways to include igv.js, using the experimental [tmp_es6_igv](https://www.npmjs.com/package/tmp_es6_igv) NPM package:
* [ES6 `import` in React](https://github.com/eweitz/igv.js-react), specifically [package.json](https://github.com/eweitz/igv.js-react/blob/5f95ca7f4ec3b9a67820fa87f8b34d6548cb0cd7/package.json#L6) and [App.js](https://github.com/eweitz/igv.js-react/blob/master/src/App.js#L6)
* [AMD `require`](https://jsfiddle.net/mogbkej0/5/)
* [`script` tag](https://jsfiddle.net/mq54x2y6/6/)