### PR TITLE
Enable previewing NPM package via `npm pack`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "2.0.0-rc5",
   "description": "Embeddable genomic visualization component based on the Integrative Genomics Viewer",
   "main": "dist/igv.esm.js",
-  "files": ["dist/**"],
+  "files": [
+    "dist/**"
+  ],
   "scripts": {
-    "prepublishOnly": "grunt"
+    "prepack": "grunt"
   },
   "author": {
     "name": "Jim Robinson",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,33 @@
 {
-  "name": "IGV",
-  "version": "0.0.1",
+  "name": "igv",
+  "version": "2.0.0-rc5",
+  "description": "Embeddable genomic visualization component based on the Integrative Genomics Viewer",
+  "main": "dist/igv.esm.js",
+  "files": ["dist/**"],
+  "scripts": {
+    "prepublishOnly": "grunt"
+  },
+  "author": {
+    "name": "Jim Robinson",
+    "email": "igv-team@broadinstitute.org",
+    "url": "https://igv.org"
+  },
+  "bugs": {
+    "url": "https://github.com/igvteam/igv.js/issues"
+  },
+  "bundleDependencies": false,
+  "deprecated": false,
+  "homepage": "https://igv.org",
+  "keywords": [
+    "IGV",
+    "genomics",
+    "visualization"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/igvteam/igv.js.git"
+  },
   "devDependencies": {
     "grunt": "1.0.3",
     "grunt-contrib-concat": "1.0.1",


### PR DESCRIPTION
The [package.json improvements](https://github.com/igvteam/igv.js/commit/0c551bb1dcfe3f062671d83ec055faf06acf471c) in #702 included adding `scripts` and `files` properties to package.json to build igv.js artifacts before publishing to NPM, and to strip other files from the package.  

While replying to [Jim's comment from yesterday](https://github.com/igvteam/igv.js/issues/701#issuecomment-411629051), it occurred to me that the `scripts` property could be refined.

This updates the `scripts` property to run Grunt during `npm pack`, in addition to `npm publish`.  It enables developers to preview what the igv NPM package will contain before publishing.

Using package.json has benefits over using external (e.g. Jenkins) build scripts: 1) it is open source (with all the benefits that brings), 2) it's in line with mainstream JS conventions, and 3) it requires less maintenance of things handled out-of-the-box by the `npm` client.

Here's an example of how this would be used:
```
# Ensure devDependencies like grunt are available

$ npm install --only=dev
npm notice created a lockfile as package-lock.json. You should commit this file.
added 130 packages from 104 contributors and audited 303 packages in 2.778s
found 0 vulnerabilities

# `npm pack` enables you to preview the tarballed package that goes to NPM.
# The files that go into the tarball are defined by the `files` property in package.json, 
# and by default includes conventional files like any README and LICENSE.
# `npm pack` gives a dry run of `npm publish`.

$ npm pack

> igv@2.0.0-rc5 prepack /Library/WebServer/Documents/igv.js
> grunt

Running "concat:css" (concat) task

Running "embed-css" task

Running "concat:igv" (concat) task

Running "concat:igv_es6" (concat) task

Running "uglify:igv" (uglify) task
>> 1 sourcemap created.
>> 1 file created 2.45 MB → 1.48 MB

Running "uglify:igv_esm" (uglify) task
>> 1 sourcemap created.
>> 1 file created 2.45 MB → 1.47 MB

Done.
npm notice 
npm notice 📦  igv@2.0.0-rc5
npm notice === Tarball Contents === 
npm notice 843B    package.json           
npm notice 1.1kB   license.txt            
npm notice 295B    README.md              
npm notice 2.5MB   dist/igv.esm.js        
npm notice 1.5MB   dist/igv.esm.min.js    
npm notice 799.7kB dist/igv.esm.min.js.map
npm notice 2.5MB   dist/igv.js            
npm notice 1.5MB   dist/igv.min.js        
npm notice 799.5kB dist/igv.min.js.map    
npm notice === Tarball Details === 
npm notice name:          igv                                     
npm notice version:       2.0.0-rc5                               
npm notice filename:      igv-2.0.0-rc5.tgz                       
npm notice package size:  2.6 MB                                  
npm notice unpacked size: 9.5 MB                                  
npm notice shasum:        d67aaccc6f2adb703d711177c9b109c77ac82916
npm notice integrity:     sha512-VDuaLP5v/TgEs[...]R7gvmqCHceRQw==
npm notice total files:   9                                       
npm notice 
igv-2.0.0-rc5.tgz
```