### PR TITLE
Make sure NPM works, yet prevent accidental publishing of the package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "igv",
-  "version": "VERSION",
+  "version": "2.0.0-rc5",
+  "private": true,
   "description": "Embeddable genomic visualization component based on the Integrative Genomics Viewer",
   "main": "dist/igv.esm.js",
   "files": [


### PR DESCRIPTION
Same stop-gap measure as before - prevent publishing - but this does not break npm because of invalid version string.