### PR TITLE
Avoid save/restore whenever possible

### DIFF
--- a/js/igv-canvas.js
+++ b/js/igv-canvas.js
@@ -69,14 +69,17 @@ var igv = (function (igv) {
 
             log("stroke line, prop: " + properties);
 
-            ctx.save();
-            if (properties) igv.graphics.setProperties(ctx, properties);
+            if (properties) {
+                ctx.save();
+                igv.graphics.setProperties(ctx, properties);
+            }
 
             ctx.beginPath();
             ctx.moveTo(x1, y1);
             ctx.lineTo(x2, y2);
             ctx.stroke();
-            ctx.restore();
+
+            if (properties) ctx.restore();
         },
 
         fillRect: function (ctx, x, y, w, h, properties) {
@@ -96,33 +99,38 @@ var igv = (function (igv) {
         },
 
         fillPolygon: function (ctx, x, y, properties) {
-            ctx.save();
-            if (properties)   igv.graphics.setProperties(ctx, properties);
-            doPath(ctx, x, y);
-            ctx.fill();
-            ctx.restore();
-        },
-
-        strokePolygon: function (ctx, x, y, properties) {
-            ctx.save();
-            if (properties)   igv.graphics.setProperties(ctx, properties);
-            doPath(ctx, x, y);
-            ctx.stroke();
-            ctx.restore();
-        },
-
-        fillText: function (ctx, text, x, y, properties, transforms) {
-
             if (properties) {
                 ctx.save();
                 igv.graphics.setProperties(ctx, properties);
             }
+            doPath(ctx, x, y);
+            ctx.fill();
+            if (properties) ctx.restore();
+        },
 
+        strokePolygon: function (ctx, x, y, properties) {
+            if (properties) {
+                ctx.save();
+                igv.graphics.setProperties(ctx, properties);
+            }
+            doPath(ctx, x, y);
+            ctx.stroke();
+            if (properties) ctx.restore();
+        },
 
-            ctx.save();
+        fillText: function (ctx, text, x, y, properties, transforms) {
 
-            ctx.translate(x, y);
+            if (properties || transforms) {
+                ctx.save();
+            }
+
+            if (properties) {
+                igv.graphics.setProperties(ctx, properties);
+            }
+
             if (transforms) {
+                // Slow path with context saving and extra translate
+                ctx.translate(x, y);
 
                 for (var transform in transforms) {
                     var value = transforms[transform];
@@ -136,26 +144,28 @@ var igv = (function (igv) {
                     }
                 }
 
+                ctx.fillText(text, 0, 0);
+            }
+            else {
+                ctx.fillText(text, x, y);
             }
 
-            ctx.fillText(text, 0, 0);
-            ctx.restore();
-
-            if (properties) ctx.restore();
-
+            if (properties || transforms) ctx.restore();
         },
 
         strokeText: function (ctx, text, x, y, properties, transforms) {
 
 
-            ctx.save();
+            if (properties || transforms) {
+                ctx.save();
+            }
+
             if (properties) {
                 igv.graphics.setProperties(ctx, properties);
             }
 
-
-            ctx.translate(x, y);
             if (transforms) {
+                ctx.translate(x, y);
 
                 for (var transform in transforms) {
                     var value = transforms[transform];
@@ -168,12 +178,14 @@ var igv = (function (igv) {
                         ctx.rotate(value['angle'] * Math.PI / 180);
                     }
                 }
+
+                ctx.strokeText(text, 0, 0);
+            }
+            else {
+                ctx.strokeText(text, x, y);
             }
 
-
-            ctx.strokeText(text, 0, 0);
-            ctx.restore();
-
+            if (properties || transforms) ctx.restore();
         },
 
         strokeCircle: function (ctx, x, y, radius) {
@@ -210,14 +222,16 @@ var igv = (function (igv) {
         },
 
         dashedLine: function (ctx, x1, y1, x2, y2, dashLen, properties) {
-            ctx.save();
             x1 = Math.round(x1);
             y1 = Math.round(y1);
             x2 = Math.round(x2);
             y2 = Math.round(y2);
             dashLen = Math.round(dashLen);
             log("dashedLine");
-            if (properties) igv.graphics.setProperties(ctx, properties);
+            if (properties) {
+                ctx.save();
+                igv.graphics.setProperties(ctx, properties);
+            }
 
             if (dashLen == undefined) dashLen = 2;
             ctx.moveTo(x1, y1);
@@ -236,12 +250,11 @@ var igv = (function (igv) {
             }
             ctx[q % 2 == 0 ? 'moveTo' : 'lineTo'](x2, y2);
 
-            ctx.restore();
+            if (properties) ctx.restore();
         },
 
         roundRect: function (ctx, x, y, width, height, radius, fill, stroke) {
 
-            ctx.save();
             if (typeof stroke == "undefined") {
                 stroke = true;
             }
@@ -265,11 +278,9 @@ var igv = (function (igv) {
             if (fill) {
                 ctx.fill();
             }
-            ctx.restore();
         },
         polygon: function (ctx, x, y, fill, stroke) {
 
-            ctx.save();
             if (typeof stroke == "undefined") {
                 stroke = true;
             }
@@ -289,7 +300,6 @@ var igv = (function (igv) {
             if (fill) {
                 ctx.fill();
             }
-            ctx.restore();
         }
 
 


### PR DESCRIPTION
The save/restore pairs are quite slow especially in loops executing
thousands of times. Usually the save/restore is needed only when
properties are being set. For untransformed text drawing, a fast
path was added that draws text directly without save/transform/restore.