### PR TITLE
Remove second removeBrowser function

### DIFF
--- a/js/igv-create.js
+++ b/js/igv-create.js
@@ -471,12 +471,6 @@ var igv = (function (igv) {
 
     }
 
-    igv.removeBrowser = function (browser) {
-        browser.$root.remove();
-        browser.dispose();
-        //$(".igv-generic-dialog-container").remove();   // TODO -- this is global, needs to be specific for this browser
-    };
-
 
     function extractQuery(config) {
 


### PR DESCRIPTION
There are 2 removeBrowser functions in igv-create.js, with the second one throwing an error upon usage. This function is needed as we are using virtual lists to render thousands of sequencing results and need to cleanup the browsers that are no longer in the view. (Though once we scroll through about 10 browsers, it still crashes)