### PR TITLE
Show genome name

### DIFF
--- a/js/browser.js
+++ b/js/browser.js
@@ -351,8 +351,8 @@ var igv = (function (igv) {
 
                 genomeChange = self.genome && (self.genome.id !== genome.id);
                 self.genome = genome;
-                self.$current_genome.text(genome.id || '');
-                self.$current_genome.attr('title', genome.id || '');
+                self.$current_genome.text(genome.name || genome.id || '');
+                self.$current_genome.attr('title', genome.name || genome.id || '');
                 self.chromosomeSelectWidget.update(genome);
 
                 if (genomeChange) {

--- a/js/genome.js
+++ b/js/genome.js
@@ -111,6 +111,7 @@ var igv = (function (igv) {
 
         this.config = config;
         this.id = config.id;
+        this.name = config.name;
         this.sequence = sequence;
         this.chromosomeNames = sequence.chromosomeNames;
         this.chromosomes = sequence.chromosomes;  // An object (functions as a dictionary)


### PR DESCRIPTION
Shows the genome "name" in the browser header instead of the id.
Tested locally.
The spacing between the "IGV" logo and the genome name could use some work though.
If you don't like this, feel free to close

Cheers
M