### PR TITLE
Color picker event handling fix. Stop propagation.

### DIFF
--- a/js/trackView.js
+++ b/js/trackView.js
@@ -719,11 +719,13 @@ var igv = (function (igv) {
                         $swatch.get(0).style.borderColor = 'white';
                     });
 
-                $swatch.click(function () {
+                $swatch.on('click.trackview', (event) => {
+                    event.stopPropagation();
                     colorHandler(color);
                 });
 
-                $swatch.on('touchend', function () {
+                $swatch.on('touchend.trackview',  (event) => {
+                    event.stopPropagation();
                     colorHandler(color);
                 });
 


### PR DESCRIPTION
Color picker event handling fix. Stop propagation. To support the juicebox colorpicker PR.