### PR TITLE
fix bug with using a function for track color

### DIFF
--- a/js/trackView.js
+++ b/js/trackView.js
@@ -661,7 +661,7 @@ var igv = (function (igv) {
 
         let appleColors = Object.values(igv.appleCrayonPalette);
 
-        if (defaultColor) {
+        if (defaultColor && !(typeof defaultColor === 'function')) {
 
             // Remove 'snow' color.
             appleColors.splice(11, 1);


### PR DESCRIPTION
Specifying track color as a function works again, e.g.

var track_colour_test_wig = {
	"type": "wig",
	"name": "colour_test_wig",
	"url": "data/colour_test.bedGraph.gz",
	"min": 0,
	"max": 5,
	"color": function (x) { return "rgb(0,0,255)"; },
	"height": 100
};