### PR TITLE
bug fix - await on igvxhr.loadString

### DIFF
--- a/js/feature/featureFileReader.js
+++ b/js/feature/featureFileReader.js
@@ -243,7 +243,7 @@ FeatureFileReader.prototype.loadFeaturesWithIndex = async function (chr, start, 
                 parse(inflated);
 
             } else {
-                const inflated = igvxhr.loadString(config.url, options);
+                const inflated = await igvxhr.loadString(config.url, options);
                 parse(inflated);
             }
 


### PR DESCRIPTION
it seems that the `await` operator is missing since `igvxhr.loadString` is async..