### PR TITLE
AED allows a 0 for feature start.

### DIFF
--- a/js/feature/featureParsers.js
+++ b/js/feature/featureParsers.js
@@ -1186,7 +1186,7 @@ function decodeAed(tokens, ignore) {
 
     var feature = new AedFeature(this.aed, tokens);
 
-    if (!feature.chr || !feature.start || !feature.end) {
+    if (!feature.chr || (!feature.start && feature.start!==0) || !feature.end) {
         console.log('Cannot parse feature: ' + tokens.join(','));
         return undefined;
     }


### PR DESCRIPTION
Unfortunately, 0 is false-y so the test was incorrectly failing to parse a legitimate feature.

Sorry, this came out only when I was doing a very thorough test, normally people have no features at 0.