### PR TITLE
Instead of erroring, provide slice of loaded data

### DIFF
--- a/js/igvxhr.js
+++ b/js/igvxhr.js
@@ -200,7 +200,8 @@ const igvxhr = {
                         if (xhr.status === 0 || (xhr.status >= 200 && xhr.status <= 300)) {
                             if (range && xhr.status !== 206 && range.start !== 0) {
                                 // For small files a range starting at 0 can return the whole file => 200
-                                handleError("ERROR: range-byte header was ignored for url: " + url);
+                                // Provide just the slice we asked for, throw out the rest quietly
+                                resolve(xhr.response.slice(range.start, range.start + range.size));
                             } else {
                                 resolve(xhr.response);
                             }

--- a/js/igvxhr.js
+++ b/js/igvxhr.js
@@ -199,9 +199,15 @@ const igvxhr = {
                         // when the url points to a local file, the status is 0 but that is not an error
                         if (xhr.status === 0 || (xhr.status >= 200 && xhr.status <= 300)) {
                             if (range && xhr.status !== 206 && range.start !== 0) {
-                                // For small files a range starting at 0 can return the whole file => 200
-                                // Provide just the slice we asked for, throw out the rest quietly
-                                resolve(xhr.response.slice(range.start, range.start + range.size));
+                                if (xhr.response.length < 100000) {
+                                    // For small files a range starting at 0 can return the whole file => 200
+                                    // Provide just the slice we asked for, throw out the rest quietly
+                                    resolve(xhr.response.slice(range.start, range.start + range.size));
+                                } else {
+                                    // Error out if the file is large but the server is not supporting range requests
+                                    // If you see this error, disable indexing or make the server support range requests
+                                    handleError("ERROR: range-byte header was ignored for url: " + url);
+                                }
                             } else {
                                 resolve(xhr.response);
                             }


### PR DESCRIPTION
I am getting ArrayBuffer from the response which has a convenient .slice method that is useful for this sort of situation.

Fixing issue #1049 