### PR TITLE
gCNV track

### DIFF
--- a/dev/gcnv.html
+++ b/dev/gcnv.html
@@ -34,6 +34,11 @@
                     indexURL: './data/gcnv/cc_29_3.dcr.subset.bed.gz.tbi',
                     indexed: true,
                     height: 300,
+                    highlightSamples: {
+                      "C2035_VCGS_FAM141_443_v1_Exome_GCP": "blue",
+                      "C2035_VCGS_FAM124_390_v1_Exome_GCP": "blue",
+                      "C2035_VCGS_FAM108_337_v1_Exome_GCP": "red",
+                    },
                 },
 
                 {
@@ -48,9 +53,6 @@
                     displayMode: 'EXPANDED',
                     order: 1000001,
                     color: 'rgb(76,171,225)',
-                    highlightSamples: {
-
-                    },
                 },
             ]
         };

--- a/dev/gcnv.html
+++ b/dev/gcnv.html
@@ -16,10 +16,7 @@
 </head>
 
 <body>
-
-<h1>1000 Genomes CRAM file</h1>
-
-<div id="igvDiv" style="padding-top: 50px;padding-bottom: 20px; height: auto"></div>
+<div id="igvDiv" style="padding-top: 20px;padding-bottom: 20px; height: auto"></div>
 
 <script type="module">
 
@@ -32,10 +29,29 @@
                 {
                     type: 'gcnv',
                     format: 'gcnv',
+                    name: 'gCNV1',
                     url: './data/gcnv/cc_29_3.dcr.subset.bed.gz',
                     indexURL: './data/gcnv/cc_29_3.dcr.subset.bed.gz.tbi',
-                    indexed: true
-                }
+                    indexed: true,
+                    height: 300,
+                },
+
+                {
+                    name: 'Gencode v32 Genes',
+                    format: 'refgene',
+                    url: 'https://storage.googleapis.com/seqr-reference-data/GRCh38/gencode/gencode_v32_knownGene.sorted.txt.gz',
+                    indexUrl: 'https://storage.googleapis.com/seqr-reference-data/GRCh38/gencode/gencode_v32_knownGene.sorted.txt.gz.tbi',
+                    indexed: true,
+                    searchable: true,
+                    height: 350,
+                    visibilityWindow: -1,
+                    displayMode: 'EXPANDED',
+                    order: 1000001,
+                    color: 'rgb(76,171,225)',
+                    highlightSamples: {
+
+                    },
+                },
             ]
         };
 

--- a/dev/gcnv.html
+++ b/dev/gcnv.html
@@ -30,8 +30,8 @@
                     type: 'gcnv',
                     format: 'gcnv',
                     name: 'gCNV1',
-                    url: './data/gcnv/cc_29_3.dcr.subset.bed.gz',
-                    indexURL: './data/gcnv/cc_29_3.dcr.subset.bed.gz.tbi',
+                    url: './data/gcnv/cc_29_3.dcr.bed.gz',
+                    indexURL: './data/gcnv/cc_29_3.dcr.bed.gz.tbi',
                     indexed: true,
                     height: 300,
                     highlightSamples: {

--- a/dev/gcnv.html
+++ b/dev/gcnv.html
@@ -32,7 +32,7 @@
                 {
                     type: 'gcnv',
                     format: 'gcnv',
-                    url: './data/gcnv/cc_29_3.dcr.first100.bed.gz',
+                    url: './data/gcnv/cc_29_3.dcr.subset.bed.gz',
                     indexed: false
                 }
             ]

--- a/dev/gcnv.html
+++ b/dev/gcnv.html
@@ -33,7 +33,8 @@
                     type: 'gcnv',
                     format: 'gcnv',
                     url: './data/gcnv/cc_29_3.dcr.subset.bed.gz',
-                    indexed: false
+                    indexURL: './data/gcnv/cc_29_3.dcr.subset.bed.gz.tbi',
+                    indexed: true
                 }
             ]
         };

--- a/dev/gcnv.html
+++ b/dev/gcnv.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta content="IE=edge" http-equiv="X-UA-Compatible">
+    <meta content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" name="viewport">
+    <meta content="" name="description">
+    <meta content="" name="author">
+    <link href=../img/favicon.ico rel="shortcut icon">
+    <title>IGV - Dev</title>
+
+    <!-- IGV CSS -->
+
+    <link href="css/dev.css" rel="stylesheet" type="text/css"/>
+
+</head>
+
+<body>
+
+<h1>1000 Genomes CRAM file</h1>
+
+<div id="igvDiv" style="padding-top: 50px;padding-bottom: 20px; height: auto"></div>
+
+<script type="module">
+
+    import igv from "../js/api.js";
+
+    var options =
+        {
+            genome: "hg38",
+            tracks: [
+                {
+                    type: 'gcnv',
+                    format: 'gcnv',
+                    url: './data/gcnv/cc_29_3.dcr.first100.bed.gz',
+                    indexed: false
+                }
+            ]
+        };
+
+    var igvDiv = document.getElementById("igvDiv");
+
+    igv.createBrowser(igvDiv, options)
+        .then(function (browser) {
+            console.log("Created IGV browser");
+            window.igvBrowser = browser;
+        })
+
+
+</script>
+
+</body>
+
+</html>

--- a/js/feature/featureFileReader.js
+++ b/js/feature/featureFileReader.js
@@ -26,6 +26,7 @@
 import FeatureParser from "./featureParsers.js";
 import SegParser from "./segParser.js";
 import VcfParser from "../variant/vcfParser.js";
+import GCNVParser from "../gcnv/gcnvParser.js";
 import loadBamIndex from "../bam/bamIndex.js";
 import loadTribbleIndex from "./tribble.js"
 import igvxhr from "../igvxhr.js";
@@ -153,6 +154,8 @@ FeatureFileReader.prototype.getParser = function (format, decode, config) {
             return new VcfParser(config);
         case "seg" :
             return new SegParser();
+        case "gcnv" :
+            return new GCNVParser();
         default:
             return new FeatureParser(format, decode, this.config);
     }

--- a/js/gcnv/gcnvParser.js
+++ b/js/gcnv/gcnvParser.js
@@ -31,7 +31,7 @@ class GCNVParser {
       }
     }
 
-    console.warn('Parsed', allFeatures.length, 'features from', sampleNames.length, 'samples: ', sampleNames);
+    console.warn('Parsed', allFeatures.length, 'features from', sampleNames.length, 'samples');
 
     return allFeatures;
   }
@@ -41,6 +41,7 @@ class GCNVParser {
       const dataWrapper = getDataWrapper(data);
 
       this.sampleNames = dataWrapper.nextLine().split("\t").slice(3);
+      console.warn('Parsed', this.sampleNames.length, 'samples from gCNV track file header:', this.sampleNames);
     }
 
     return this.sampleNames;

--- a/js/gcnv/gcnvParser.js
+++ b/js/gcnv/gcnvParser.js
@@ -4,7 +4,7 @@ class GCNVParser {
   parseFeatures(data) {
     if (!data) return null;
 
-    console.warn('Parse features')
+
     const sampleNames = this.parseHeader(data);
 
     const dataWrapper = getDataWrapper(data);
@@ -31,16 +31,19 @@ class GCNVParser {
       }
     }
 
-    console.warn('Parsed', allFeatures.length, 'features from', sampleNames.length, 'samples')
-    return allFeatures
+    console.warn('Parsed', allFeatures.length, 'features from', sampleNames.length, 'samples: ', sampleNames);
+
+    return allFeatures;
   }
 
   parseHeader(data) {
-    const dataWrapper = getDataWrapper(data);
+    if (!this.sampleNames) {
+      const dataWrapper = getDataWrapper(data);
 
-    const sampleNames = dataWrapper.nextLine().split("\t").slice(3);
+      this.sampleNames = dataWrapper.nextLine().split("\t").slice(3);
+    }
 
-    return sampleNames;
+    return this.sampleNames;
   }
 }
 

--- a/js/gcnv/gcnvParser.js
+++ b/js/gcnv/gcnvParser.js
@@ -1,56 +1,37 @@
 import getDataWrapper from "../feature/dataWrapper.js";
-import {splitLines} from "../util/stringUtils.js";
 
 class GCNVParser {
   parseFeatures(data) {
     if (!data) return null;
-    // Read locus
-    const sampleNames = this.parseHeader(data);
-    const allFeatures = [];
-    const dataWrapper = getDataWrapper(data);
-    let i = 0
-    let line;
-    while (line = dataWrapper.nextLine()) {
-      i += 1
-      let tokens = line.split("\t");
 
+    console.warn('Parse features')
+    const sampleNames = this.parseHeader(data);
+
+    const dataWrapper = getDataWrapper(data);
+
+    let line;
+    let i = 0;
+    const allFeatures = [];
+    while (line = dataWrapper.nextLine()) {
+      i += 1;
+      let tokens = line.split("\t");
 
       const chr = tokens[0];
       const start = parseInt(tokens[1]);
       const end = parseInt(tokens[2]);
+      const values = tokens.slice(3).map(parseFloat);
 
-
-      const values = tokens.slice(3).map(function (v, j) {
-        v = parseFloat(v)
-        return [sampleNames[j], v]
-      });
-
-      allFeatures.push({
-        chr: chr,
-        start: start,
-        end: end,
-        values: values,
-      })
-
-      /*
-      for (let j = 0; j < sampleNames.length; j++) {
-
-        if (tokens.length > j) {
-          const sampleName = sampleNames[j];
-          const value = parseFloat(tokens[j]);
-          allFeatures.push({
-            sampleKey: sampleName,
-            sample: sampleName,
-            chr: chr,
-            start: start,
-            end: end,
-            value: value
-          });
-        }
+      if (values.length == sampleNames.length) {
+        allFeatures.push({
+          chr: chr,
+          start: start,
+          end: end,
+          values: values,
+        })
       }
-      */
     }
 
+    console.warn('Parsed', allFeatures.length, 'features from', sampleNames.length, 'samples')
     return allFeatures
   }
 

--- a/js/gcnv/gcnvParser.js
+++ b/js/gcnv/gcnvParser.js
@@ -1,0 +1,73 @@
+import getDataWrapper from "../feature/dataWrapper.js";
+import {splitLines} from "../util/stringUtils.js";
+
+class GCNVParser {
+  parseFeatures(data) {
+    if (!data) return null;
+
+    const dataWrapper = getDataWrapper(data);
+
+    // Read locus
+    const sampleNames = this.parseHeader(dataWrapper.nextLine());
+    const allFeatures = [];
+
+    let i = 0
+    let line;
+    while (line = dataWrapper.nextLine()) {
+      i += 1
+      let tokens = line.split("\t");
+
+
+      const chr = tokens[0];
+      const start = parseInt(tokens[1]);
+      const end = parseInt(tokens[2]);
+
+
+      const values = tokens.slice(3).map(function (v, j) {
+        v = parseFloat(v)
+        return [sampleNames[j], v]
+      });
+
+      allFeatures.push({
+        chr: chr,
+        start: start,
+        end: end,
+        values: values,
+      })
+
+      if (i == 1) {
+        console.warn(values);
+      }
+      /*
+      for (let j = 0; j < sampleNames.length; j++) {
+
+        if (tokens.length > j) {
+          const sampleName = sampleNames[j];
+          const value = parseFloat(tokens[j]);
+          allFeatures.push({
+            sampleKey: sampleName,
+            sample: sampleName,
+            chr: chr,
+            start: start,
+            end: end,
+            value: value
+          });
+        }
+      }
+      */
+    }
+
+    console.warn('Parsed', allFeatures.length, ' gcnv rows')
+
+    return allFeatures
+  }
+
+  parseHeader(line) {
+    const tokens = line.split("\t");
+
+    return tokens.slice(3)
+  }
+}
+
+export default GCNVParser
+

--- a/js/gcnv/gcnvParser.js
+++ b/js/gcnv/gcnvParser.js
@@ -4,13 +4,10 @@ import {splitLines} from "../util/stringUtils.js";
 class GCNVParser {
   parseFeatures(data) {
     if (!data) return null;
-
-    const dataWrapper = getDataWrapper(data);
-
     // Read locus
-    const sampleNames = this.parseHeader(dataWrapper.nextLine());
+    const sampleNames = this.parseHeader(data);
     const allFeatures = [];
-
+    const dataWrapper = getDataWrapper(data);
     let i = 0
     let line;
     while (line = dataWrapper.nextLine()) {
@@ -35,9 +32,6 @@ class GCNVParser {
         values: values,
       })
 
-      if (i == 1) {
-        console.warn(values);
-      }
       /*
       for (let j = 0; j < sampleNames.length; j++) {
 
@@ -57,15 +51,15 @@ class GCNVParser {
       */
     }
 
-    console.warn('Parsed', allFeatures.length, ' gcnv rows')
-
     return allFeatures
   }
 
-  parseHeader(line) {
-    const tokens = line.split("\t");
+  parseHeader(data) {
+    const dataWrapper = getDataWrapper(data);
 
-    return tokens.slice(3)
+    const sampleNames = dataWrapper.nextLine().split("\t").slice(3);
+
+    return sampleNames;
   }
 }
 

--- a/js/gcnv/gcnvTrack.js
+++ b/js/gcnv/gcnvTrack.js
@@ -144,9 +144,9 @@ GCNVTrack.prototype.draw = function (options) {
             const y = yScale(value);
             const previousValue = previousValues.values[sampleName]
             if (!isNaN(previousValue)) {
-                IGVGraphics.strokeLine(ctx, previousX, yScale(previousValue), x1, y, {strokeStyle: 'gray'});
+                IGVGraphics.strokeLine(ctx, previousX, yScale(previousValue), x1, y, {strokeStyle: '#D9D9D9'});
             }
-            IGVGraphics.strokeLine(ctx, x1, y, x2, y);
+            IGVGraphics.strokeLine(ctx, x1, y, x2, y, {strokeStyle: 'gray'});
 
             previousValues.values[sampleName] = value;
 

--- a/js/gcnv/gcnvTrack.js
+++ b/js/gcnv/gcnvTrack.js
@@ -1,0 +1,350 @@
+import FeatureSource from './featureSource.js';
+import TDFSource from "../tdf/tdfSource.js";
+import TrackBase from "../trackBase.js";
+import BWSource from "../bigwig/bwSource.js";
+import IGVGraphics from "../igv-canvas.js";
+import paintAxis from "../util/paintAxis.js";
+import IGVColor from "../igv-color.js";
+import MenuUtils from "../ui/menuUtils.js";
+import {createCheckbox} from "../igv-icons.js";
+import {numberFormatter} from "../util/stringUtils.js";
+import {extend} from "../util/igvUtils.js";
+import FeatureTrack from "./featureTrack.js";
+import {visibilityChange} from "../igv-create.js";
+
+const dataRangeMenuItem = MenuUtils.dataRangeMenuItem;
+
+const GcnvTrack = extend(TrackBase,
+
+    function (config, browser) {
+
+        this.type = "wig";
+
+        this.featureType = 'numeric';
+
+        // Default color, might be overridden by track line
+        if (config.color === undefined) {
+            config.color = "rgb(150,150,150)";
+        }
+
+        if (config.height === undefined) {
+            config.height = 50;
+        }
+
+        TrackBase.call(this, config, browser);
+
+        const format = config.format ? config.format.toLowerCase() : config.format;
+        if ("bigwig" === format) {
+            this.featureSource = new BWSource(config, browser.genome);
+        } else if ("tdf" === format) {
+            this.featureSource = new TDFSource(config, browser.genome);
+        } else {
+            this.featureSource = new FeatureSource(config, browser.genome);
+        }
+
+        this.autoscale = config.autoscale || config.max === undefined;
+        if (!this.autoscale) {
+            this.dataRange = {
+                min: config.min || 0,
+                max: config.max
+            }
+        }
+
+        this.windowFunction = config.windowFunction || "mean";
+        this.paintAxis = paintAxis;
+        this.graphType = config.graphType || "bar";
+
+    });
+
+GcnvTrack.prototype.postInit = async function () {
+    const header = await this.getFileHeader();
+    if (header) this.setTrackProperties(header)
+}
+
+GcnvTrack.prototype.getFeatures = async function (chr, bpStart, bpEnd, bpPerPixel) {
+    return this.featureSource.getFeatures(chr, bpStart, bpEnd, bpPerPixel, this.windowFunction);
+
+}
+
+GcnvTrack.prototype.menuItemList = function () {
+
+    var self = this,
+        menuItems = [];
+
+    menuItems.push(dataRangeMenuItem(this.trackView));
+
+    menuItems.push({
+        object: createCheckbox("Autoscale", self.autoscale),
+        click: function () {
+            self.autoscale = !self.autoscale;
+            self.config.autoscale = self.autoscale;
+            self.trackView.setDataRange(undefined, undefined, self.autoscale);
+        }
+    });
+
+    return menuItems;
+
+};
+
+GcnvTrack.prototype.getFileHeader = async function () {
+
+    if (typeof this.featureSource.getFileHeader === "function") {
+        this.header = await this.featureSource.getFileHeader();
+    }
+    return this.header;
+};
+
+GcnvTrack.prototype.draw = function (options) {
+
+    let self = this;
+
+    const features = options.features;
+    const ctx = options.context;
+    const bpPerPixel = options.bpPerPixel;
+    const bpStart = options.bpStart;
+    const pixelWidth = options.pixelWidth;
+    const pixelHeight = options.pixelHeight;
+    const bpEnd = bpStart + pixelWidth * bpPerPixel + 1;
+    let lastXPixel = -1;
+    let lastValue = -1;
+    let lastNegValue = 1;
+
+    let baselineColor;
+    if (typeof self.color === "string" && self.color.startsWith("rgb(")) {
+        baselineColor = IGVColor.addAlpha(self.color, 0.1);
+    }
+
+    const yScale = (yValue) => {
+        return ( (self.dataRange.max - yValue) / (self.dataRange.max - self.dataRange.min) ) * pixelHeight
+    };
+
+    const getX = function (feature) {
+        let x = Math.floor((feature.start - bpStart) / bpPerPixel);
+        if (isNaN(x)) console.log('isNaN(x). feature start ' + numberFormatter(feature.start) + ' bp start ' + numberFormatter(bpStart));
+        return x;
+    };
+
+    const getWidth  = function (feature, x) {
+        const rectEnd = Math.ceil((feature.end - bpStart) / bpPerPixel);
+        return Math.max(1, rectEnd - x);
+    };
+
+    const drawGuideLines = function (options) {
+        if (self.config.hasOwnProperty('guideLines')) {
+            for (let line of self.config.guideLines) {
+                if (line.hasOwnProperty('color') && line.hasOwnProperty('y') && line.hasOwnProperty('dotted')) {
+                    let y = yScale(line.y);
+                    let props = {
+                        'strokeStyle': line['color'],
+                        'strokeWidth': 2
+                    };
+                    if (line['dotted']) IGVGraphics.dashedLine(options.context, 0, y, options.pixelWidth, y, 5, props);
+                    else IGVGraphics.strokeLine(options.context, 0, y, options.pixelWidth, y, props);
+                }
+            }
+        }
+    };
+
+    if (features && features.length > 0) {
+
+        if (self.dataRange.min === undefined) self.dataRange.min = 0;
+
+        // Max can be less than min if config.min is set but max left to autoscale.   If that's the case there is
+        // nothing to paint.
+        if (self.dataRange.max > self.dataRange.min) {
+
+            if (renderFeature.end < bpStart) return;
+            if (renderFeature.start > bpEnd) return;
+
+            for (let f of features) {
+                renderFeature(f)
+            }
+
+            // If the track includes negative values draw a baseline
+            if (self.dataRange.min < 0) {
+                const basepx = (self.dataRange.max / (self.dataRange.max - self.dataRange.min)) * options.pixelHeight;
+                IGVGraphics.strokeLine(ctx, 0, basepx, options.pixelWidth, basepx, {strokeStyle: baselineColor});
+            }
+        }
+    }
+
+    drawGuideLines(options);
+
+    function renderFeature(feature) {
+        if (feature.value < self.dataRange.min) return;
+        const y = yScale(feature.value);
+        const x = getX(feature);
+
+        if (isNaN(x)) return;
+
+        const height = yScale(0) - y;
+        const width = getWidth(feature, x);
+
+        let c = (feature.value < 0 && self.altColor) ? self.altColor : self.color;
+        const color = (typeof c === "function") ? c(feature.value) : c;
+
+        if (self.graphType === "points") {
+            const pointSize = self.config.pointSize || 3;
+            const px = x + width / 2;
+            IGVGraphics.fillCircle(ctx, px, y, pointSize / 2, {"fillStyle": color, "strokeStyle": color});
+
+        } else {
+            IGVGraphics.fillRect(ctx, x, y, width, height, {fillStyle: color});
+            lastXPixel = x + width;
+            if (feature.value > 0) {
+                lastValue = feature.value;
+            } else if (feature.value < 0) {
+                lastNegValue = feature.value;
+            }
+        }
+    }
+};
+
+GcnvTrack.prototype.popupData = function (clickState, features) {
+
+    // We use the featureCache property rather than method to avoid async load.  If the
+    // feature is not already loaded this won't work,  but the user wouldn't be mousing over it either.
+
+    if (!features) features = this.clickedFeatures(clickState);
+
+    if (features && features.length > 0) {
+
+        let genomicLocation = clickState.genomicLocation;
+        let referenceFrame = clickState.viewport.genomicState.referenceFrame;
+        let popupData = [];
+
+        // We need some tolerance around genomicLocation, start with +/- 2 pixels
+        let tolerance = 2 * referenceFrame.bpPerPixel;
+        let selectedFeature = binarySearch(features, genomicLocation, tolerance);
+
+        if (selectedFeature) {
+            let posString = (selectedFeature.end - selectedFeature.start) === 1 ?
+                numberFormatter(selectedFeature.start + 1)
+                : numberFormatter(selectedFeature.start + 1) + "-" + numberFormatter(selectedFeature.end);
+            popupData.push({name: "Position:", value: posString});
+            popupData.push({
+                name: "Value:&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;",
+                value: numberFormatter(selectedFeature.value)
+            });
+        }
+
+        return popupData;
+
+
+    } else {
+        return [];
+    }
+}
+
+/**
+ * Called when the track is removed.  Do any needed cleanup here
+ */
+GcnvTrack.prototype.dispose = function () {
+    this.trackView = undefined;
+}
+
+
+function signsDiffer(a, b) {
+    return (a > 0 && b < 0 || a < 0 && b > 0);
+}
+
+/**
+ * Return the closest feature to the genomic position +/- the specified tolerance.  Closest is defined
+ * by the minimum of the distance between position and start or end of the feature.
+ *
+ * @param features
+ * @param position
+ * @returns {*}
+ */
+function binarySearch(features, position, tolerance) {
+    var startIndex = 0,
+        stopIndex = features.length - 1,
+        index = (startIndex + stopIndex) >> 1,
+        candidateFeature,
+        tmp;
+
+
+    // Use binary search to get the index of at least 1 feature in the click tolerance bounds
+    while (!test(features[index], position, tolerance) && startIndex < stopIndex) {
+        if (position < features[index].start) {
+            stopIndex = index - 1;
+        } else if (position > features[index].end) {
+            startIndex = index + 1;
+        }
+
+        index = (startIndex + stopIndex) >> 1;
+    }
+
+    if (test(features[index], position, tolerance)) {
+
+        candidateFeature = features[index];
+        if (test(candidateFeature, position, 0)) return candidateFeature;
+
+        // Else, find closest feature to click
+        tmp = index;
+        while (tmp-- >= 0) {
+            if (!test(features[tmp]), position, tolerance) {
+                break;
+            }
+            if (test(features[tmp], position, 0)) {
+                return features[tmp];
+            }
+            if (delta(features[tmp], position) < delta(candidateFeature, position)) {
+                candidateFeature = features[tmp];
+            }
+
+            tmp = index;
+            while (tmp++ < features.length) {
+                if (!test(features[tmp]), position, tolerance) {
+                    break;
+                }
+                if (test(features[tmp], position, 0)) {
+                    return features[tmp];
+                }
+                if (delta(features[tmp], position) < delta(candidateFeature, position)) {
+                    candidateFeature = features[tmp];
+                }
+            }
+        }
+        return candidateFeature;
+
+    } else {
+        console.log(position + ' not found!');
+        return undefined;
+    }
+
+    function test(feature, position, tolerance) {
+        return position >= (feature.start - tolerance) && position <= (feature.end + tolerance);
+    }
+
+    function delta(feature, position) {
+        return Math.min(Math.abs(feature.start - position), Math.abs(feature.end - position));
+    }
+}
+
+GcnvTrack.prototype.getState = function () {
+
+    let config = this.config;
+
+    config.autoscale = this.autoscale;
+
+    if (!this.autoscale && this.dataRange) {
+        config.min = this.dataRange.min;
+        config.max = this.dataRange.max;
+    }
+    return config;
+
+}
+
+GcnvTrack.prototype.supportsWholeGenome = function () {
+
+    if (typeof this.featureSource.supportsWholeGenome === 'function') {
+        return this.featureSource.supportsWholeGenome();
+    } else {
+        return false;
+    }
+
+}
+
+
+export default GcnvTrack;

--- a/js/gcnv/gcnvTrack.js
+++ b/js/gcnv/gcnvTrack.js
@@ -7,6 +7,9 @@ import {extend, isSimpleType} from "../util/igvUtils.js";
 import IGVColor from "../igv-color.js";
 import {numberFormatter} from "../util/stringUtils.js";
 import paintAxis from "../util/paintAxis.js";
+import MenuUtils from "../ui/menuUtils.js";
+
+const dataRangeMenuItem = MenuUtils.dataRangeMenuItem;
 
 const GCNVTrack = extend(TrackBase,
 
@@ -67,10 +70,10 @@ GCNVTrack.prototype.draw = function (options) {
     const pixelHeight = options.pixelHeight;
     const bpEnd = bpStart + pixelWidth * bpPerPixel + 1;
 
-    let baselineColor;
-    if (typeof self.color === "string" && self.color.startsWith("rgb(")) {
-        baselineColor = IGVColor.addAlpha(self.color, 0.1);
-    }
+    ///let baselineColor;
+    //if (typeof self.color === "string" && self.color.startsWith("rgb(")) {
+    //    baselineColor = IGVColor.addAlpha(self.color, 0.1);
+    //}
 
     const yScale = (yValue) => {
         return ( (self.dataRange.max - yValue) / (self.dataRange.max - self.dataRange.min) ) * pixelHeight
@@ -113,12 +116,14 @@ GCNVTrack.prototype.draw = function (options) {
             for (let f of features) {
                 renderFeature(previousValues, f);
             }
-
+            
+            /*
             // If the track includes negative values draw a baseline
             if (self.dataRange.min < 0) {
                 const basepx = (self.dataRange.max / (self.dataRange.max - self.dataRange.min)) * options.pixelHeight;
                 IGVGraphics.strokeLine(ctx, 0, basepx, options.pixelWidth, basepx, {strokeStyle: baselineColor});
             }
+            */
         }
     }
 
@@ -133,9 +138,6 @@ GCNVTrack.prototype.draw = function (options) {
 
         //let c = (feature.value < 0 && self.altColor) ? self.altColor : self.color;
         //const color = (typeof c === "function") ? c(feature.value) : c;
-
-        //const height = yScale(0) - y;
-        //const width = getWidth(feature, x);
 
         //const pointSize = self.config.pointSize || 3;
         for (let i = 0; i < feature.values.length; i++) {
@@ -162,9 +164,6 @@ GCNVTrack.prototype.draw = function (options) {
         previousValues.end = feature.end;
 
     }
-
-    console.warn('done with draw')
-
 };
 
 
@@ -172,7 +171,6 @@ GCNVTrack.prototype.doAutoscale = function(features) {
 
     var min, max;
 
-    console.warn('start autoscale')
     if (features.length > 0) {
         min = Number.MAX_VALUE;
         max = -Number.MAX_VALUE;
@@ -188,8 +186,7 @@ GCNVTrack.prototype.doAutoscale = function(features) {
         max = 100;
     }
 
-    console.warn('done autoscale')
-    return {min: min, max: max};
+    return {min: min - 0.01, max: max + 0.01};
 }
 
 

--- a/js/gcnv/gcnvTrack.js
+++ b/js/gcnv/gcnvTrack.js
@@ -8,6 +8,7 @@ import {numberFormatter} from "../util/stringUtils.js";
 import paintAxis from "../util/paintAxis.js";
 import MenuUtils from "../ui/menuUtils.js";
 
+const X_PIXEL_DIFF_THRESHOLD = 1;
 const dataRangeMenuItem = MenuUtils.dataRangeMenuItem;
 
 const GCNVTrack = extend(TrackBase,
@@ -132,6 +133,7 @@ GCNVTrack.prototype.draw = function (options) {
         const x2 = getX(feature.end);
 
         if (isNaN(x1) || isNaN(x2)) return;
+        if ((x1 - previousX < X_PIXEL_DIFF_THRESHOLD) && (x2 - x1 < X_PIXEL_DIFF_THRESHOLD)) return;
 
         //let c = (feature.value < 0 && self.altColor) ? self.altColor : self.color;
         //const color = (typeof c === "function") ? c(feature.value) : c;
@@ -141,11 +143,17 @@ GCNVTrack.prototype.draw = function (options) {
             const sampleName = self.header[i];
             const value = feature.values[i];
             const y = yScale(value);
-            const previousValue = previousValues.values[sampleName]
-            if (!isNaN(previousValue)) {
-                IGVGraphics.strokeLine(ctx, previousX, yScale(previousValue), x1, y, {strokeStyle: '#D9D9D9'});
+            if (x1 - previousX >= X_PIXEL_DIFF_THRESHOLD) {
+                const previousValue = previousValues.values[sampleName]
+                if (!isNaN(previousValue)) {
+                    const previousY = yScale(previousValue);
+                    IGVGraphics.strokeLine(ctx, previousX, previousY, x1, y, {strokeStyle: '#D9D9D9'});
+                }
             }
-            IGVGraphics.strokeLine(ctx, x1, y, x2, y, {strokeStyle: 'gray'});
+
+            if (x2 - x1 >= X_PIXEL_DIFF_THRESHOLD) {
+                IGVGraphics.strokeLine(ctx, x1, y, x2, y, {strokeStyle: 'gray'});
+            }
 
             previousValues.values[sampleName] = value;
 

--- a/js/gcnv/gcnvTrack.js
+++ b/js/gcnv/gcnvTrack.js
@@ -238,7 +238,6 @@ GCNVTrack.prototype.clickedFeatures = function (clickState) {
     let key = null;
     for(key of Object.keys(this.clickDetectorCache)) {
         key = parseInt(key)
-        console.warn(key)
         if(key >= clickX) {
             break
         }

--- a/js/gcnv/gcnvTrack.js
+++ b/js/gcnv/gcnvTrack.js
@@ -4,7 +4,6 @@ import TrackBase from "../trackBase.js";
 import IGVGraphics from "../igv-canvas.js";
 import {createCheckbox} from "../igv-icons.js";
 import {extend, isSimpleType} from "../util/igvUtils.js";
-import IGVColor from "../igv-color.js";
 import {numberFormatter} from "../util/stringUtils.js";
 import paintAxis from "../util/paintAxis.js";
 import MenuUtils from "../ui/menuUtils.js";
@@ -35,7 +34,6 @@ GCNVTrack.prototype.postInit = async function () {
 }
 
 GCNVTrack.prototype.menuItemList = function () {
-
     const self = this;
     const menuItems = [];
     menuItems.push(dataRangeMenuItem(this.trackView));
@@ -50,7 +48,6 @@ GCNVTrack.prototype.menuItemList = function () {
     });
 
     return menuItems;
-
 };
 
 
@@ -105,7 +102,7 @@ GCNVTrack.prototype.draw = function (options) {
 
         if (self.dataRange.min === undefined) self.dataRange.min = 0;
 
-        // Max can be less than min if config.min is set but max left to autoscale.   If that's the case there is
+        // Max can be less than min if config.min is set but max left to autoscale. If that's the case there is
         // nothing to paint.
         if (self.dataRange.max > self.dataRange.min) {
 
@@ -116,7 +113,7 @@ GCNVTrack.prototype.draw = function (options) {
             for (let f of features) {
                 renderFeature(previousValues, f);
             }
-            
+
             /*
             // If the track includes negative values draw a baseline
             if (self.dataRange.min < 0) {
@@ -169,8 +166,7 @@ GCNVTrack.prototype.draw = function (options) {
 
 GCNVTrack.prototype.doAutoscale = function(features) {
 
-    var min, max;
-
+    let min, max;
     if (features.length > 0) {
         min = Number.MAX_VALUE;
         max = -Number.MAX_VALUE;
@@ -180,13 +176,15 @@ GCNVTrack.prototype.doAutoscale = function(features) {
             max = Math.max(max, ...feature.values);
         });
 
+        min -= 0.01;
+        max += 0.01;
     } else {
         // No features -- default
         min = 0;
         max = 100;
     }
 
-    return {min: min - 0.01, max: max + 0.01};
+    return {min: min, max: max};
 }
 
 

--- a/js/trackFactory.js
+++ b/js/trackFactory.js
@@ -8,6 +8,7 @@ import InteractionTrack from "./feature/interactionTrack.js";
 import VariantTrack from "./variant/variantTrack.js";
 import EqtlTrack from "./gtex/eqtlTrack.js";
 import GWASTrack from "./gwas/gwasTrack.js";
+import GCNVTrack from "./gcnv/gcnvTrack.js";
 import RnaStructTrack from "./rna/rnaStruct.js";
 
 const TrackFactory = {
@@ -43,6 +44,9 @@ const TrackFactory = {
     },
     'arc': (config, browser) => {
         return new RnaStructTrack(config, browser);
+    },
+    'gcnv': (config, browser) => {
+        return new GCNVTrack(config, browser);
     }
 }
 

--- a/js/trackView.js
+++ b/js/trackView.js
@@ -485,7 +485,7 @@ TrackView.prototype.updateViews = async function (force) {
         }
 
         if (typeof this.track.doAutoscale === 'function') {
-            this.track.doAutoscale(allFeatures);
+            this.track.dataRange = this.track.doAutoscale(allFeatures);
         } else {
             this.track.dataRange = doAutoscale(allFeatures);
         }


### PR DESCRIPTION
Track for displaying normalized coverage data generated by gCNV

![image](https://user-images.githubusercontent.com/6240170/73796802-3e012280-477c-11ea-88ad-2c7bf637bc4a.png)

The underlying data format is a modified .bed-like file with a tab-separated header row, follow by data rows with chrom, start, end fields followed by per-sample copy-number floating-point values like
```
chrom    start       end      sample1   sample2   sample3   
chr1     12345     54321        1.3        2.5        3    
chr1     55555     66666        1.0        2.1       1.2 
``` 

This file must be bgzip compressed and have a tabix index.