### PR TITLE
Minor typo in unknown genome alert

### DIFF
--- a/js/browser.js
+++ b/js/browser.js
@@ -443,7 +443,7 @@ Browser.prototype.loadGenome = async function (idOrConfig, initialLocus) {
 
             var reference = knownGenomes[genomeID];
             if (!reference) {
-                this.presentAlert("Uknown genome id: " + genomeID, undefined);
+                this.presentAlert("Unknown genome id: " + genomeID, undefined);
             }
             return reference;
         } else {


### PR DESCRIPTION
Just fixes a typo I came across when I specified an invalid genome.