### PR TITLE
Allow HTML in the popover for variant custom reader

### DIFF
--- a/js/viewport.js
+++ b/js/viewport.js
@@ -830,8 +830,10 @@ class ViewPort extends ViewportBase {
                 if (nameValue.name) {
                     const str = `<span>${nameValue.name}</span>&nbsp&nbsp&nbsp${nameValue.value}`
                     return `<div title="${nameValue.value}">${str}</div>`
-                } else if ('<hr>' === nameValue) {
+                } else if ('<hr>' === nameValue) { // this can be retired if nameValue.html is allowed.
                     return nameValue
+                } else if (nameValue.html) {
+                    return nameValue.html
                 } else {
                     return `<div title="${nameValue}">${nameValue}</div>`
                 }


### PR DESCRIPTION
We needed a way to create a custom variant reader and have a button to view more information in the popup dialog. This enables that by doing something like:

` fields.push({ html: '<button>Some button for this variant</button>'});`

as part of the `Variant.prototype.popupData` function in the custom reader.

Also, this "feature" would also get rid of the hardcoded checking for "<hr>". Although that does break compatibility for anyone who relied on this (no hurt in keep it there).