### PR TITLE
Fix bug: Empty text features list causes error

### DIFF
--- a/js/feature/textFeatureSource.js
+++ b/js/feature/textFeatureSource.js
@@ -313,7 +313,7 @@ function packFeatures(features, maxRows) {
  */
 function fixFeatures(features, genome) {
 
-    if (!features || features.length === 0) return;
+    if (!features || features.length === 0) return [];
 
     const isBedPE = features[0].chr === undefined && features[0].chr1 !== undefined;
     if (isBedPE) {


### PR DESCRIPTION
I use igv js for displaying features in annotation-tracks via the `feature`-option. When a track-feature-list is empty an error dialog is displayed.

Example code:
```js
const config = {
        reference: {
          id: "my genome",
          fastaURL: this.fastaUrl,
          indexed: false,
          tracks: [
            {
               name: "empty",
               type: "annotation",
               features: [],
            }
          ],
          wholeGenomeView: false
        },
      };
```

Error:
![image](https://user-images.githubusercontent.com/6919146/117930614-7cca4480-b2fe-11eb-84c8-f4250be5c5a5.png)

The error appears in the `FeatureCache` constructor, but is caused by not returning a list from `fixFeatures`. This patch fixes the `fixFeatures` method. It might also be an option to check if the `featurelist` object is `undefined` in the `FeatureCache`-constructor.
