### PR TITLE
Fix undefined variable when no seq stored in bam for a read

### DIFF
--- a/js/bam/alignmentContainer.js
+++ b/js/bam/alignmentContainer.js
@@ -319,7 +319,7 @@ class CoverageMap {
                     self.coverage[i] = new Coverage(self.threshold);
                 }
 
-                const base = seq.charAt(seqOffset + j);
+                const base = (seq == undefined) ? "N" : seq.charAt(seqOffset + j);
                 const key = (alignment.strand) ? "pos" + base : "neg" + base;
                 const q = qual && seqOffset + j < qual.length ? qual[seqOffset + j] : 30;
 


### PR DESCRIPTION
Secondary alignments with no sequence stored in the bam/cram file (such as produced by minimap2) crash igv.js with ugly popup saying `Cannot read property 'charAt' of undefined`  and console showing 
```
viewport.js:222 TypeError: Cannot read property 'charAt' of undefined
    at n (alignmentContainer.js:322)
    at alignmentContainer.js:278
    at Array.forEach (<anonymous>)
    at ra.incCounts (alignmentContainer.js:277)
    at ea.push (alignmentContainer.js:70)
    at Ch.readAlignments (cramReader.js:170)
    at async Ih.getAlignments (bamSource.js:103)
    at async Fh.getFeatures (bamTrack.js:144)
    at async Wr.getFeatures (viewport.js:557)
    at async Wr.loadFeatures (viewport.js:201)
```

Example problematic sam line is:
```
7f6556bb-3235-42d9-8c17-b9c9d83328b2	256	chr11	1915532	0	7594S29M4D8M2D7M1I5M1I5M5I12M11I41M7D4M1D13M1D13M4D16M1I6M3I19M6288S	*	0	0	*	*NM:i:54	ms:i:148	AS:i:148	nn:i:0	tp:A:S	cm:i:5	s1:i:54	de:f:0.1316	rl:i:1056
```

This pull request should fix it.