### PR TITLE
rulerViewport: check tooltip defined in mouseMove/setTimeout

### DIFF
--- a/js/rulerViewport.js
+++ b/js/rulerViewport.js
@@ -115,7 +115,9 @@ class RulerViewport extends ViewPort {
                 currentViewport = this
                 this.$tooltip.show()
             } else if (currentViewport.guid !== this.guid) {
-                currentViewport.$tooltip.hide()
+                if (currentViewport.$tooltip) {
+                    currentViewport.$tooltip.hide();
+                }
                 this.$tooltip.show()
                 currentViewport = this
             } else {

--- a/js/rulerViewport.js
+++ b/js/rulerViewport.js
@@ -142,7 +142,11 @@ class RulerViewport extends ViewPort {
 
             // hide tooltip when movement stops
             clearTimeout(timer)
-            timer = setTimeout(() => this.$tooltip.hide(),toolTipTimeout)
+            timer = setTimeout(() => {
+                if (this.$tooltip) {
+                    this.$tooltip.hide()
+                }
+            }, toolTipTimeout)
 
         }
 


### PR DESCRIPTION
Problem: After igv.js is closed, a setTimeout might trigger, which is then tying to read an undefined `$tooltip` property.

![Selection_381](https://user-images.githubusercontent.com/11461352/133786320-5939b79c-ddf8-4a4f-896e-feca58430644.png)

This PR checks if the `$tooltip` property is defined. 
