### PR TITLE
Add an option to disable continuous update of a track's content while panning

### DIFF
--- a/js/trackBase.js
+++ b/js/trackBase.js
@@ -89,6 +89,8 @@ class TrackBase {
 
         this.visibilityWindow = config.visibilityWindow
 
+        this.panContinuousUpdate = (config.panContinuousUpdate === undefined) ? true : config.panContinuousUpdate;
+
         this.trackView = undefined
     }
 

--- a/js/trackView.js
+++ b/js/trackView.js
@@ -382,11 +382,11 @@ class TrackView {
         // Shift viewports left/right to current genomic state (pans canvas)
         visibleViewports.forEach(viewport => viewport.shift());
 
+        // rpv: viewports whose image (canvas) does not fully cover current genomic range
         const reloadableViewports = this.viewportsToReload(force);
 
         // Do not update data if currently dragging and continuous update disabled
         if (!isDragging || this.track.panContinuousUpdate){
-            // rpv: viewports whose image (canvas) does not fully cover current genomic range
 
             // Trigger viewport to load features needed to cover current genomic range
             for (let viewport of reloadableViewports) {
@@ -442,7 +442,7 @@ class TrackView {
             for (let visibleViewport of visibleViewports) {
                 visibleViewport.repaint();
             }
-        } else {
+        } else if (!isDragging || this.track.panContinuousUpdate) {
             for (let vp of reloadableViewports) {
                 vp.repaint();
             }


### PR DESCRIPTION
Currently, IGV.js updates the content of the tracks continuously while the user is panning.
This may trigger multiple simultaneous, redundant feature reads and redraws while the user is panning on the browser, as each `mousemove` event reloads the whole visibility window, around the same width on each side, and redraws the whole thing.

While this makes perfect sense for local files or small amounts of data, when IGV is integrated in a web app and dynamically consumes relatively large amounts of data from a remote server, this behavior rapidly creates multiple heavy requests while the user is dragging the browser, that are a huge burden on network and performance, both for the client and the server.

This pull request adds a property in the **track** configuration (to be able to disable this only for that kind of critical tracks) that allows configuring this behavior, called `panContinuousUpdate`
If `panContinuousUpdate` is set to `true` or not defined in the track config, it keeps the usual behavior, updating the track content as the user is dragging.
If it is set to `false`, it disables the content update and redraw while the user is still dragging and only updates the data when the user releases the mouse drag, and thus makes only one feature read for the whole panning, greatly reducing redundant requests.

This config option is set to `true` by default, to keep the existing behavior when not defined.

