### PR TITLE
Fail on missing initial locus

### DIFF
--- a/js/browser.js
+++ b/js/browser.js
@@ -551,7 +551,10 @@ class Browser {
         if (!locusFound) {
             console.log("Initial locus not found: " + locus);
             locus = genome.getHomeChromosomeName()
-            await this.search(locus);
+            const locusFound = await this.search(locus, true);
+            if (!locusFound) {
+                throw new Error("Cannot set initial locus");
+            }
         }
     }
 


### PR DESCRIPTION
Hello! Thank you very much for this tool, it's really useful and easy to integrate in another web app :clap: :clap:

I have just experienced some issues with a genome for which the FASTA index was wrong. Because of this, igv.js couldn't set the initial locus, but it didn't really complain about the fact (there's only a "Initial locus not found" console log). The problem is the locus sets `this.referenceFrameList` and when this doesn't happen igv.js fails at another point in code. But just seeing `referenceFrameList is undefined` doesn't give you much information, so it took me a while to realize the actual cause of the problem.

Given that the browser creation is going to fail anyways if we don't manage to set the initial location, it'd be better to have a hard fail with a more informative error message. Although I'm not sure if this is the best way to do it. Please advise if there's a better way.

> I'm also passing `init=true` in the second `search` call for consistency with the first one. Or is there a reason not to pass `init=true` in this case?