### PR TITLE
Change 'show cords' in track menus

### DIFF
--- a/js/bam/bamTrack.js
+++ b/js/bam/bamTrack.js
@@ -1163,26 +1163,8 @@ class AlignmentTrack {
         }
 
         // Experimental JBrowse feature
-        if (this.browser.circularView) {
-            const maxFragmentLenth = this.parent.maxFragmentLength;
-            list.push({
-                label: 'Show discordant pairs',
-                click: () => {
-                    const refFrame = viewport.referenceFrame;
-                    const inView = viewport.getCachedFeatures().allAlignments().filter(a => {
-                        return a.end >= refFrame.start && a.start <= refFrame.end
-                            && a.mate
-                            && a.mate.chr
-                            && (a.mate.chr !== a.chr || Math.max(a.fragmentLength) > maxFragmentLenth);
-                    })
-                    this.browser.circularViewVisible = true;
-                    const chords = makePairedAlignmentChords(inView);
-                    this.browser.circularView.addChords(chords, true);
-                }
-            });
-
-            list.push('<hr/>');
-
+        if (this.browser.circularView && true === this.browser.circularViewVisible) {
+            list.push(getDiscordantPairsMenuItem(this.browser, viewport, this.parent.maxFragmentLength), '<hr/>')
         }
 
         return list;
@@ -1323,6 +1305,32 @@ class AlignmentTrack {
         return color;
 
     }
+}
+
+function getDiscordantPairsMenuItem(browser, viewport, maxFragmentLength) {
+
+    const item =
+        {
+            label: 'Show discordant pairs',
+            click: () => {
+                const { referenceFrame } = viewport;
+                const inView = viewport.getCachedFeatures().allAlignments().filter(a => {
+                    return a.end >= referenceFrame.start
+                        && a.start <= referenceFrame.end
+                        && a.mate
+                        && a.mate.chr
+                        && (a.mate.chr !== a.chr || Math.max(a.fragmentLength) > maxFragmentLength);
+                })
+
+                browser.circularViewVisible = true;
+
+                const chords = makePairedAlignmentChords(inView);
+                browser.circularView.addChords(chords, true);
+            }
+        }
+
+        return item
+
 }
 
 function sortAlignmentRows(options, alignmentContainer) {

--- a/js/feature/interactionTrack.js
+++ b/js/feature/interactionTrack.js
@@ -422,26 +422,13 @@ class InteractionTrack extends TrackBase {
             items = items.concat(MenuUtils.numericDataMenuItems(this.trackView));
         }
 
-        // Experimental JBrowse feature
-        if (this.browser.circularView) {
-            items.push('<hr/>');
-            items.push({
-                label: 'Show chords',
-                click: () => {
-                    this.browser.circularViewVisible = true;
-                    const chords = makeBedPEChords(this.featureSource.getAllFeatures(), this.color)
-                    this.browser.circularView.addChords(chords, true);
-                }
-            });
-        }
-
         return items;
     };
 
     contextMenuItemList(clickState) {
 
         // Experimental JBrowse feature
-        if (this.browser.circularView) {
+        if (this.browser.circularView && true === this.browser.circularViewVisible) {
             const viewport = clickState.viewport;
             const list = [];
 

--- a/js/variant/variantTrack.js
+++ b/js/variant/variantTrack.js
@@ -530,22 +530,6 @@ class VariantTrack extends TrackBase {
                 });
         }
 
-        // Experimental JBrowse feature
-        if (this.browser.circularView) {
-            menuItems.push('<hr/>');
-
-            menuItems.push({
-                label: 'Show chords',
-                click: () => {
-                    this.browser.circularViewVisible = true;
-                    const chords = makeVCFChords(this.featureSource.getAllFeatures(), this.color);
-                    this.browser.circularView.addChords(chords, true);
-                }
-            });
-
-        }
-
-
         return menuItems;
     }
 
@@ -553,7 +537,7 @@ class VariantTrack extends TrackBase {
     contextMenuItemList(clickState) {
 
         // Experimental JBrowse feature
-        if (this.browser.circularView) {
+        if (this.browser.circularView && true === this.browser.circularViewVisible) {
             const viewport = clickState.viewport;
             const list = [];
 


### PR DESCRIPTION
- Remove from gear menu
- Show in context menu only when circular-viewer is displayed
- 