### PR TITLE
bug fix - IGV js hangs and crashes browser if something is "off" in the url

### DIFF
--- a/js/igv-create.js
+++ b/js/igv-create.js
@@ -235,6 +235,8 @@ function extractQuery(config) {
                     config[key] = value
                 }
                 i = j + 1
+            } else {
+                i++;
             }
         }
     }


### PR DESCRIPTION
bug fix - when loading the igv, if you don't provide an explicit `queryParametersSupported: false` in the options object, the igv iterates over current query parameters looking for parameters of certain names (like 'file') and appends them to the config. and if, by any chance, you have corruption in the url (like we had an accidental `&&` in the middle), the igv loading hangs the browser (goes into infinite loop). this simple fix solves this (if a query param is somehow invalid, move on to the next)