### PR TITLE
allow the display of insertion/deletion base counts

### DIFF
--- a/js/bam/bamTrack.js
+++ b/js/bam/bamTrack.js
@@ -783,8 +783,10 @@ class AlignmentTrack {
         this.posStrandColor = config.posStrandColor || "rgba(230, 150, 150, 0.75)"
         this.insertionColor = config.insertionColor || "rgb(138, 94, 161)"
         this.insertionTextColor = config.insertionTextColor || "white"
+        this.showInsertionText = config.showInsertionText === undefined ? false : !!config.showInsertionText
         this.deletionColor = config.deletionColor || "black"
         this.deletionTextColor = config.deletionTextColor || "black"
+        this.showDeletionText = config.showDeletionText === undefined ? false : !!config.showDeletionText
         this.skippedColor = config.skippedColor || "rgb(150, 170, 170)"
         this.pairConnectorColor = config.pairConnectorColor
 
@@ -1009,7 +1011,7 @@ class AlignmentTrack {
                     })
 
                     // Add gap width as text like Java IGV if it fits nicely and is a multi-base gap
-                    if (gap.len > 1 && lineWidth >= gapTextWidth + 8) {
+                    if (this.showDeletionText && gap.len > 1 && lineWidth >= gapTextWidth + 8) {
                         const textStart = gapCenter - (gapTextWidth / 2)
                         IGVGraphics.fillRect(ctx, textStart - 1, yRect - 1, gapTextWidth + 2, 12, {fillStyle: "white"})
                         IGVGraphics.fillText(ctx, gapLenText, textStart, yRect + 10, {
@@ -1037,7 +1039,9 @@ class AlignmentTrack {
                     const insertLenText = insertionBlock.len.toString()
 
                     const textPixelWidth = 2 + (insertLenText.length * 6)
-                    const basePixelWidth = insertionBlock.len === 1 ? 2 : Math.round(insertionBlock.len / bpPerPixel)
+                    const basePixelWidth = (!this.showInsertionText || insertionBlock.len === 1)
+                        ? 2
+                        : Math.round(insertionBlock.len / bpPerPixel)
                     const widthBlock = Math.max(Math.min(textPixelWidth, basePixelWidth), 2)
 
                     const xBlockStart = (refOffset / bpPerPixel) - (widthBlock / 2)
@@ -1054,7 +1058,7 @@ class AlignmentTrack {
                         // Show # of inserted bases as text if it's a multi-base insertion and the insertion block
                         // is wide enough to hold text (its size is capped at the text label size, but can be smaller
                         // if the browser is zoomed out and the insertion is small)
-                        if (insertionBlock.len > 1 && basePixelWidth > textPixelWidth) {
+                        if (this.showInsertionText && insertionBlock.len > 1 && basePixelWidth > textPixelWidth) {
                             IGVGraphics.fillText(ctx, insertLenText, xBlockStart + 1, yRect + 10, {
                                 'font': 'normal 10px monospace',
                                 'fillStyle': this.insertionTextColor,

--- a/js/bam/bamTrack.js
+++ b/js/bam/bamTrack.js
@@ -782,7 +782,9 @@ class AlignmentTrack {
         this.negStrandColor = config.negStrandColor || "rgba(150, 150, 230, 0.75)"
         this.posStrandColor = config.posStrandColor || "rgba(230, 150, 150, 0.75)"
         this.insertionColor = config.insertionColor || "rgb(138, 94, 161)"
+        this.insertionTextColor = config.insertionTextColor || "white"
         this.deletionColor = config.deletionColor || "black"
+        this.deletionTextColor = config.deletionTextColor || "black"
         this.skippedColor = config.skippedColor || "rgb(150, 170, 170)"
         this.pairConnectorColor = config.pairConnectorColor
 
@@ -1012,7 +1014,7 @@ class AlignmentTrack {
                         IGVGraphics.fillRect(ctx, textStart - 1, yRect - 1, gapTextWidth + 2, 12, {fillStyle: "white"})
                         IGVGraphics.fillText(ctx, gapLenText, textStart, yRect + 10, {
                             'font': 'normal 10px monospace',
-                            'fillStyle': 'black',
+                            'fillStyle': this.deletionTextColor,
                         })
                     }
                 }
@@ -1055,7 +1057,7 @@ class AlignmentTrack {
                         if (insertionBlock.len > 1 && basePixelWidth > textPixelWidth) {
                             IGVGraphics.fillText(ctx, insertLenText, xBlockStart + 1, yRect + 10, {
                                 'font': 'normal 10px monospace',
-                                'fillStyle': 'white',  // TODO: configurable
+                                'fillStyle': this.insertionTextColor,
                             })
                         }
                         lastXBlockStart = xBlockStart

--- a/js/bam/bamTrack.js
+++ b/js/bam/bamTrack.js
@@ -1047,13 +1047,11 @@ class AlignmentTrack {
                     const xBlockStart = (refOffset / bpPerPixel) - (widthBlock / 2)
                     if ((xBlockStart - lastXBlockStart) > 2) {
                         const props = {fillStyle: this.insertionColor}
-                        IGVGraphics.fillRect(ctx, xBlockStart, yRect, widthBlock, alignmentHeight, props)
 
                         // Draw decorations like Java IGV to make an 'I' shape
-                        IGVGraphics.fillRect(ctx, xBlockStart - 2, yRect, 2, 2, props)
-                        IGVGraphics.fillRect(ctx, xBlockStart - 2, yRect + alignmentHeight - 2, 2, 2, props)
-                        IGVGraphics.fillRect(ctx, xBlockStart + widthBlock, yRect, 2, 2, props)
-                        IGVGraphics.fillRect(ctx, xBlockStart + widthBlock, yRect + alignmentHeight - 2, 2, 2, props)
+                        IGVGraphics.fillRect(ctx, xBlockStart - 2, yRect, widthBlock + 4, 2, props)
+                        IGVGraphics.fillRect(ctx, xBlockStart, yRect + 2, widthBlock, alignmentHeight - 4, props)
+                        IGVGraphics.fillRect(ctx, xBlockStart - 2, yRect + alignmentHeight - 2, widthBlock + 4, 2, props)
 
                         // Show # of inserted bases as text if it's a multi-base insertion and the insertion block
                         // is wide enough to hold text (its size is capped at the text label size, but can be smaller


### PR DESCRIPTION
addresses #1498 

Adds 4 new config options for alignment tracks:

* `insertionTextColor` (default: white)
* `showInsertionText` (default: false)
* `deletionTextColor` (default: black)
* `showDeletionText`: (default: false)

if both insertion and deletion text are shown via the above options, it may look something like this (example with CCS reads + HTT expansion; ignore the read colours):
<img width="647" alt="Screen Shot 2022-06-16 at 6 09 41 PM" src="https://user-images.githubusercontent.com/357970/174186642-27064aae-f4c2-419b-b576-c6db3b61465e.png">

there is also a bit of logic to decide when to stop drawing these labels when the user is zoomed out enough.

this also changes bases to be drawn on top of insertions/deletions to match the Java version. this can be reverted fairly easily if desired. gaps are now also drawn underneath insertions to display more intuitively.

If this PR is merged, I agree to transfer the copyright of these changes to the copyright holders of the `igv.js` repository.