### PR TITLE
Add visibilityWindow for WigTrack

### DIFF
--- a/js/feature/wigTrack.js
+++ b/js/feature/wigTrack.js
@@ -88,6 +88,7 @@ class WigTrack extends TrackBase {
             start,
             end,
             bpPerPixel,
+            visibilityWindow: this.visibilityWindow,
             windowFunction: this.windowFunction
         })
         if (this.normalize && this.featureSource.normalizationFactor) {


### PR DESCRIPTION
Enable (smaller) partial reading of indexed wig-like files.  It's probably been a programming error to provide `windowFunction` instead of `visibilityWindow` to that funciton.



A different isssue: The UI for using tsv+bgzip+tabix for numerical data on arbitrary column is quite cumbersome. I managed with track:
```
{
    name: this_track_name,
    url: fname,
    indexURL: fname + ".tbi",
    order: track_idx,
    type: "wig,
    format: "gwas",
    visibilityWindow: vis_window,
    columns: {
        chromosome: 1,
        position: 2,
        value: value_column
    }
}
```
note `type="wig", format="gwas"`.  Plain `type="tsv"` would be nicer.