### PR TITLE
use nameField when parsing BED files

### DIFF
--- a/js/feature/decode/ucsc.js
+++ b/js/feature/decode/ucsc.js
@@ -34,7 +34,10 @@ function decodeBed(tokens, header) {
                 const attributeKVs = parseAttributeString(tokens[3], '=')
                 feature.attributes = {}
                 for (let kv of attributeKVs) {
-                    feature.attributes[kv[0]] = kv[1]
+                    feature.attributes[kv[0]] = kv[1];
+                    if (header.nameField != undefined && kv[0] === header.nameField) {
+                        feature.name = kv[1];
+                    }
                 }
             }
             if (!feature.name) {

--- a/test/data/bed/gfftags.bed
+++ b/test/data/bed/gfftags.bed
@@ -1,0 +1,5 @@
+#gffTags
+track name="chr1" description="chr1 Annotations" itemRgb="On"
+chr1	1088	1128	Key1=INS230;Key2=Foo	0	+	1088	1088	65,105,225
+chr1	133	2809	Key2=Bar;Key1=terminator	0	+	133	133	65,105,225
+chr1	1301	1746	Key1=M13 origin;Key2=Baz	0	+	1301	1301	65,105,225

--- a/test/testBED.js
+++ b/test/testBED.js
@@ -358,5 +358,22 @@ suite("testBed", function () {
         assert.equal(23, features.length);   // # of features over this region
     })
 
+    test("gffTags/nameField", async function () {
+        const config = {
+            type: "annotation",
+            format: "bed",
+            delimiter: "\t",
+            indexed: false,
+            nameField: "Key1",
+            url: require.resolve("./data/bed/gfftags.bed")
+        }
+        const reader = new FeatureFileReader(config);
+        const features = await reader.readFeatures("chr1", 0, Number.MAX_VALUE);
+        assert.ok(features);
+        assert.equal(features.length, 3);
+        assert.equal(features[1].name, 'terminator');
+        assert.equal(features[2].name, 'M13 origin');
+    })
+
 })
 


### PR DESCRIPTION
The purpose of this patch is to honor the `nameField` configuration option when creating annotation tracks from BED files which use a `gffTags` name field.