### PR TITLE
take ViewLimits into account when coloring featureTrack

### DIFF
--- a/js/feature/featureTrack.js
+++ b/js/feature/featureTrack.js
@@ -454,8 +454,8 @@ class FeatureTrack extends TrackBase {
             color = IGVColor.addAlpha(color, feature.alpha)
         } else if (this.useScore && feature.score && !Number.isNaN(feature.score)) {
             // UCSC useScore option, for scores between 0-1000.  See https://genome.ucsc.edu/goldenPath/help/customTrack.html#TRACK
-            const min = this.config.min ? this.config.min : 0 //getViewLimitMin(track);
-            const max = this.config.max ? this.config.max : 1000 //getViewLimitMax(track);
+            const min = this.dataRange.min ? this.dataRange.min : 0 //getViewLimitMin(track);
+            const max = this.dataRange.max ? this.dataRange.max : 1000 //getViewLimitMax(track);
             const alpha = getAlpha(min, max, feature.score)
             feature.alpha = alpha    // Avoid computing again
             color = IGVColor.addAlpha(color, alpha)


### PR DESCRIPTION
The purpose of this PR is to fix featureTrack shading when `useScore` and `viewLimits` headers are provided. `igv.js` already parses the `viewLimits` tag in BED headers, but then uses the `this.config.min` and `this.config.max` values in the actual color calculations. I wasn't able to figure out where these values are coming from, but they're not from the `viewLimits` parsing code, which sets the `dataRange` property of the track.

I wasn't sure how to modify the test suite to accommodate this change.