### PR TITLE
decode all URI-encoded BED attributes

### DIFF
--- a/js/feature/decode/ucsc.js
+++ b/js/feature/decode/ucsc.js
@@ -31,7 +31,7 @@ function decodeBed(tokens, header) {
 
             // Potentially parse name field as GFF column 9 style streng.
             if (tokens[3].indexOf(';') > 0 && tokens[3].indexOf('=') > 0) {
-                const attributeKVs = parseAttributeString(tokens[3], '=')
+                const attributeKVs = parseAttributeString(tokens[3], '=', true)
                 feature.attributes = {}
                 for (let kv of attributeKVs) {
                     feature.attributes[kv[0]] = kv[1]

--- a/js/feature/gff/gff.js
+++ b/js/feature/gff/gff.js
@@ -113,15 +113,15 @@ function decodeGTF(tokens, header) {
  * @param keyValueDelim
  * @returns {[]}
  */
-function parseAttributeString(attributeString, keyValueDelim) {
+function parseAttributeString(attributeString, keyValueDelim, relaxed = false) {
     // parse 'attributes' string (see column 9 docs in https://github.com/The-Sequence-Ontology/Specifications/blob/master/gff3.md)
     var attributes = []
     for (let kv of attributeString.split(';')) {
         kv = kv.trim()
         const idx = kv.indexOf(keyValueDelim)
         if (idx > 0 && idx < kv.length - 1) {
-            const key = kv.substring(0, idx)
-            let value = stripQuotes(decodeGFFAttribute(kv.substring(idx + 1).trim()))
+            const key = stripQuotes(decodeGFFAttribute(kv.substring(0, idx).trim(), relaxed))
+            let value = stripQuotes(decodeGFFAttribute(kv.substring(idx + 1).trim(), relaxed))
             attributes.push([key, value])
         }
     }
@@ -160,10 +160,13 @@ const encodings = new Map([
     ["%2C", ","]
 ])
 
-function decodeGFFAttribute(str) {
+function decodeGFFAttribute(str, relaxed = false) {
 
     if (!str.includes("%")) {
         return str
+    }
+    if (relaxed) {
+        return decodeURIComponent(str);
     }
     let decoded = ""
     for (let i = 0; i < str.length; i++) {

--- a/test/data/bed/gfftags.bed
+++ b/test/data/bed/gfftags.bed
@@ -3,3 +3,4 @@ track name="chr1" description="chr1 Annotations" itemRgb="On"
 chr1	1088	1128	Key1=INS230;Key2=Foo	0	+	1088	1088	65,105,225
 chr1	133	2809	Key2=Bar;Key1=terminator	0	+	133	133	65,105,225
 chr1	1301	1746	Key1=M13 origin;Key2=Baz	0	+	1301	1301	65,105,225
+chr1	1301	1746	Key1=M13%20origin;Key%202=Baz	0	+	1301	1301	65,105,225

--- a/test/testBED.js
+++ b/test/testBED.js
@@ -370,9 +370,11 @@ suite("testBed", function () {
         const reader = new FeatureFileReader(config)
         const features = await reader.readFeatures("chr1", 0, Number.MAX_VALUE)
         assert.ok(features)
-        assert.equal(features.length, 3)
+        assert.equal(features.length, 4)
         assert.equal(features[1].name, 'terminator')
         assert.equal(features[2].name, 'M13 origin')
+        assert.equal(features[3].name, 'M13 origin')
+        assert.equal("Baz", features[3].getAttributeValue("Key 2"))
     })
 
 })

--- a/test/testGFF.js
+++ b/test/testGFF.js
@@ -307,11 +307,16 @@ CDS	    7000	7600	.	+	1	ID=cds00003;Parent=mRNA00003;Name=edenprotein.3
      */
     test("GFF3 attribute encoding", function () {
 
-        const encoded = "aaa%09b%0Acd%0De%25fgh%3Bijk%3Dlm%26nop%2C"
-        const expected = "aaa\tb\ncd\re%fgh;ijk=lm&nop,"
+        // all allowable characters from GFF3 spec should be decoded;
+        // others (here %20 = space) should be left as-is
+        const encoded = "aaa%09b%0Acd%0De%25fgh%3Bijk%3Dlm%26nop%2C%20"
+        const expected = "aaa\tb\ncd\re%fgh;ijk=lm&nop,%20"
+        const expected_relaxed = "aaa\tb\ncd\re%fgh;ijk=lm&nop, "
 
         const decoded = decodeGFFAttribute(encoded)
         assert.equal(expected, decoded)
+        const decoded_relaxed = decodeGFFAttribute(encoded, true)
+        assert.equal(expected_relaxed, decoded_relaxed)
 
     })
 })


### PR DESCRIPTION
This PR changes the behavior of BED `gffTags` attribute parsing, removing the character subset limits of the GFF3 spec in favor of URI-decoding all encoded values in the attributes. This mirrors the behavior of standalone IGV.

One additional change was made in order to also decode the attribute key (previously, only attribute value was decoded). The GFF3 spec makes no distinction between the two in discussions of encoding and escaping characters.

Several testing modifications were made to encompass these changes.