### PR TITLE
Set queryable to true for HTSGET source

### DIFF
--- a/js/feature/textFeatureSource.js
+++ b/js/feature/textFeatureSource.js
@@ -71,6 +71,7 @@ class TextFeatureSource {
             this.queryable = true
         } else if ("htsget" === config.sourceType) {
             this.reader = new HtsgetVariantReader(config, genome)
+            this.queryable = true
         } else if (config.sourceType === 'ucscservice') {
             this.reader = new UCSCServiceReader(config.source)
             this.queryable = true


### PR DESCRIPTION
It's fix for https://github.com/igvteam/igv.js/issues/1609. 

For VCF from HTSGET source, only first query for some region get data from server. All subsequent requests try to get data from cahce, but cache not contains that data.

The reason of this behaviour: in textFeatureSource.js in loadFeatures method

```
        const genomicInterval = this.queryable ?
            new GenomicInterval(queryChr, intervalStart, intervalEnd) :
            undefined
```

i.e. when later we put data into cache `genomicInterval` is `undefined`. In the cache, an `undefined` range value is interpreted as included all features.