### PR TITLE
add option for sort by start location in the right click options

### DIFF
--- a/js/bam/bamTrack.js
+++ b/js/bam/bamTrack.js
@@ -1247,6 +1247,7 @@ class AlignmentTrack {
             viewport.repaint()
         }
         list.push('<b>Sort by...</b>')
+        list.push({label: '&nbsp; start location', click: () => sortByOption("START")})
         list.push({label: '&nbsp; base', click: () => sortByOption("BASE")})
         list.push({label: '&nbsp; read strand', click: () => sortByOption("STRAND")})
         list.push({label: '&nbsp; insert size', click: () => sortByOption("INSERT_SIZE")})


### PR DESCRIPTION
There is actually a sort by start location function, but the option is missing in the right click option menu, this changes is to add back the "start location" option in the option menu