### PR TITLE
can sort as pairs when view as pairs, sort as single reads otherwise

### DIFF
--- a/js/bam/alignmentContainer.js
+++ b/js/bam/alignmentContainer.js
@@ -160,7 +160,7 @@ class AlignmentContainer {
         const newRows = []
         const undefinedRow = []
         for (let row of this.packedAlignmentRows) {
-            const alignment = row.findAlignment(options.position)
+            const alignment = row.findAlignment(options.position, options.sortAsPairs)
             if (undefined !== alignment) {
                 newRows.push(row)
             } else {

--- a/js/bam/bamAlignmentRow.js
+++ b/js/bam/bamAlignmentRow.js
@@ -23,7 +23,7 @@
  * THE SOFTWARE.
  */
 
-import {StringUtils} from "../../node_modules/igv-utils/src/index.js"
+import { StringUtils } from "../../node_modules/igv-utils/src/index.js"
 
 const isString = StringUtils.isString
 const hashCode = StringUtils.hashCode
@@ -36,17 +36,17 @@ class BamAlignmentRow {
         this.score = undefined
     }
 
-    findAlignment(genomicLocation) {
+    findAlignment(genomicLocation, sortAsPairs = false) {
 
         const alignmentContains = (a, genomicLocation) => {
-            return genomicLocation >= a.start && genomicLocation < a.start + a.lengthOnRef
+            return genomicLocation >= a.start && genomicLocation < a.start + (sortAsPairs ? a.fragmentLength : a.lengthOnRef)
         }
 
         // find single alignment that overlaps sort location
         let centerAlignment
         for (let i = 0; i < this.alignments.length; i++) {
             const a = this.alignments[i]
-            if (genomicLocation >= a.start && genomicLocation < a.start + a.lengthOnRef) {
+            if (genomicLocation >= a.start && genomicLocation < a.start + (sortAsPairs ? a.fragmentLength : a.lengthOnRef)) {
                 if (a.paired) {
                     if (a.firstAlignment && alignmentContains(a.firstAlignment, genomicLocation)) {
                         centerAlignment = a.firstAlignment
@@ -64,11 +64,11 @@ class BamAlignmentRow {
 
     }
 
-    getSortValue({position, option, tag}, alignmentContainer) {
+    getSortValue({ position, option, tag, sortAsPairs }, alignmentContainer) {
 
         if (!option) option = "BASE"
 
-        const alignment = this.findAlignment(position)
+        const alignment = this.findAlignment(position, sortAsPairs)
         if (undefined === alignment) {  // This condition should never occur
             return Number.MAX_VALUE
         }

--- a/js/bam/bamTrack.js
+++ b/js/bam/bamTrack.js
@@ -1240,7 +1240,8 @@ class AlignmentTrack {
                 chr: viewport.referenceFrame.chr,
                 position: Math.floor(clickState.genomicLocation),
                 option: option,
-                direction: direction
+                direction: direction,
+                sortAsPairs: viewport.trackView.track.viewAsPairs
             }
             this.parent.sortObject = newSortObject
             viewport.cachedFeatures.sortRows(newSortObject)


### PR DESCRIPTION
Edited code so that :
When view as pairs, sorting will find the pairs that overlap the position,
when not view as pairs, sorting will find the single reads that overlap the position.

This behaviour is actually same as the IGV desktop version.