### PR TITLE
added setReadsToHighlight() method to AlignmentTrack

### DIFF
--- a/js/bam/bamTrack.js
+++ b/js/bam/bamTrack.js
@@ -795,12 +795,22 @@ class AlignmentTrack {
         this.hideSmallIndels = config.hideSmallIndels
         this.indelSizeThreshold = config.indelSizeThreshold || 1
 
+        this.readsToHighlight = config.readsToHighlight || []
+        this.highlightedReadsOutlineColor = config.highlightedReadsOutlineColor || "#00ff00"
+
         this.hasPairs = false   // Until proven otherwise
         this.hasSupplemental = false
     }
 
     setTop(coverageTrack, showCoverage) {
         this.top = (0 === coverageTrack.height || false === showCoverage) ? 0 : (5 + coverageTrack.height)
+    }
+
+    setReadsToHighlight(readsToHighlight) {
+        if (!Array.isArray(readsToHighlight) ||!readsToHighlight.every(i => typeof i === "string")) {
+            throw new Error("AlignmentTrack.setReadsToHighlight() only accept array of strings")
+        }
+        this.readsToHighlight = readsToHighlight || []
     }
 
     /**
@@ -1079,11 +1089,13 @@ class AlignmentTrack {
                 const strokeOutline =
                     alignment.mq <= 0 ||
                     this.highlightedAlignmentReadNamed === alignment.readName ||
-                    isSoftClip
+                    isSoftClip ||
+                    this.readsToHighlight.includes(alignment.readName)
 
                 let blockOutlineColor = outlineColor
                 if (this.highlightedAlignmentReadNamed === alignment.readName) blockOutlineColor = 'red'
                 else if (isSoftClip) blockOutlineColor = 'rgb(50,50,50)'
+                else if (this.readsToHighlight.includes(alignment.readName)) blockOutlineColor = this.highlightedReadsOutlineColor
 
                 const lastBlockPositiveStrand = (true === alignment.strand && b === blocks.length - 1)
                 const lastBlockReverseStrand = (false === alignment.strand && b === 0)


### PR DESCRIPTION
added setReadsToHighlight() method to AlignmentTrack
which can take an array of read names, then highlight the reads
for example :
`const bamTracks = browser.findTracks('type', 'alignment')`
`bamTracks[0].alignmentTrack.setReadsToHighlight(["readName1", "readName2"])`
`bamTracks[0].updateViews()`

also added 
"highlightedReadsOutlineColor" (optional) 
"readsToHighlight" (optional)
in Alignment Track options,
which allow configuration of the color of the highlighted reads,
and the configuration of the reads to highlight
for example:

`{`
`  type: "alignment",`
`  format: "bam",`
`  name: "NA12889",`
`  url: "gs://genomics-public-data/platinum-genomes/bam/NA12878_S1.bam",`
`  indexURL: "gs://genomics-public-data/platinum-genomes/bam/NA12878_S1.bam.bai",`
`  sort: {`
`    chr: "chr1",`
`    position: 155155358`
`    option": "BASE",`
`    direction: "ASC"`
`  },`
`  highlightedReadsOutlineColor: "#0000ff",`
`  readsToHighlight: ["readName1", "readName2"]`
`}`
