### PR TITLE
Parse start and end as numbers in interact file

### DIFF
--- a/js/feature/decode/interact.js
+++ b/js/feature/decode/interact.js
@@ -35,8 +35,8 @@ function decodeInteract(tokens, header) {
 
     var feature = {
         chr: tokens[0],
-        start: tokens[1],
-        end: tokens[2],
+        start: Number.parseInt(tokens[1]),
+        end: Number.parseInt(tokens[2]),
 
         chr1: tokens[8],
         start1: Number.parseInt(tokens[9]),


### PR DESCRIPTION
Hi,
I'm proposing a simple adjustment to the code for parsing interact file. 
The first two indices describing region of the interaction pair were parsed as strings which caused problems when rendering interaction pairs arcs in some cases.

Based on what I've tracked down in my usecase:
- when arc type is proportional, the `dataRange.max` is used to compute `yscale` (`interactionTrack.js` file). 
- The `max` defaulted to 0 even when viewing regions with defined interactions for some genomic positions, which caused the `igv.js` to not draw `proportional` arcs while `nested` arcs could be drawn. The behavior was further inconsistent as whether the arc was drawn was dependent on genomic position and zoom level.
- The underlying reason for this is that when computing the `dataRange.max`, the feature list passed to `doAutoscale` (`interactionTrack.js` file) can be empty, since the `buildIntervalTree` (`featureUtils.js` file) uses `start` and `end` attributes of a feature, which are strings in this case (and e.g. `featureList` is then sorted lexicographically).

Based on my test build the proposed pull request fixes this issue. 
The build-in tests also finished without relevant error (apart for `HicFile remote file read header` test, which appears to be unrelated)