### PR TITLE
cnvpytor track: vcf input and structure

### DIFF
--- a/js/cnvpytor/CombinedCaller.js
+++ b/js/cnvpytor/CombinedCaller.js
@@ -6,9 +6,6 @@ class CombinedCaller{
     constructor(wigFeatures, binSize) {
         this.wigFeatures = wigFeatures
         this.binSize = binSize
-        // let fit_obj = this.get_fit()
-        // this.globalMean = fit_obj.globalMean
-        // this.globalStd = fit_obj.globalStd
     }
     get_fit(){
         var fit_info = new g_utils.GetFit(this.wigFeatures)

--- a/js/cnvpytor/cnvpytorTrack.js
+++ b/js/cnvpytor/cnvpytorTrack.js
@@ -111,14 +111,7 @@ class CNVPytorTrack extends TrackBase {
             this.featureSource = FeatureSource(this.config, this.browser.genome)
             this.header = await this.getHeader()
 
-
-            var allVariants = this.featureSource.reader.features.reduce(function (r, a) {
-                r[a.chr] = r[a.chr] || []
-                r[a.chr].push(a)
-                return r
-            }, Object.create(null))
-
-            const cnvpytor_obj = new CNVpytorVCF(allVariants, this.bin_size)
+            const cnvpytor_obj = new CNVpytorVCF(this.featureSource.reader.features, this.bin_size)
             
             let wigFeatures;
             let bafFeatures;
@@ -129,7 +122,7 @@ class CNVPytorTrack extends TrackBase {
             if(this.config.cnv_caller == '2D'){
                 
                 dataWigs = await cnvpytor_obj.read_rd_baf('2D')
-
+                
                 wigFeatures = dataWigs[0]
                 bafFeatures = dataWigs[1]
                 this.wigFeatures_obj[this.bin_size]['2D'] = wigFeatures[2]


### PR DESCRIPTION
The following changes were made for the cnvpytor track code. 

1. To mitigate memory constraints when reading the entire VCF file, elements were purged from featureSource.reader.features during SNP processing. This action frees up memory following VCF file ingestion.
2. Improve code structure for `HDF5IndexedReader.js`


- Arijit