### PR TITLE
fix ROI shift issue when saving svg

### DIFF
--- a/js/browser.js
+++ b/js/browser.js
@@ -412,7 +412,9 @@ class Browser {
             trackView.renderSVGContext(context, delta)
         }
 
-        this.roiManager.renderSVGContext(context, delta, x)
+        // ROI -> SVG
+        delta.deltaX = x
+        this.roiManager.renderSVGContext(context, delta)
 
         // reset height to trim away unneeded svg canvas real estate. Yes, a bit of a hack.
         context.setHeight(height)

--- a/js/browser.js
+++ b/js/browser.js
@@ -380,7 +380,7 @@ class Browser {
      */
     toSVG() {
 
-        const {y, width, height} = this.columnContainer.getBoundingClientRect()
+        const {x, y, width, height} = this.columnContainer.getBoundingClientRect()
 
         const h_render = 8000
 
@@ -412,7 +412,7 @@ class Browser {
             trackView.renderSVGContext(context, delta)
         }
 
-        this.roiManager.renderSVGContext(context, delta)
+        this.roiManager.renderSVGContext(context, delta, x)
 
         // reset height to trim away unneeded svg canvas real estate. Yes, a bit of a hack.
         context.setHeight(height)

--- a/js/roi/ROIManager.js
+++ b/js/roi/ROIManager.js
@@ -230,20 +230,20 @@ class ROIManager {
         return regionElement
     }
 
-    renderSVGContext(context, {deltaX, deltaY}, columnContainerX) {
+    renderSVGContext(context, {deltaX, deltaY}) {
 
         for (const regionElement of document.querySelectorAll('.igv-roi-region')) {
 
             // body
             const { x, y, width, height } = regionElement.getBoundingClientRect()
             context.fillStyle = regionElement.style.backgroundColor
-            context.fillRect(x-columnContainerX, y+deltaY, width, height)
+            context.fillRect(x-deltaX, y+deltaY, width, height)
 
             // header
             const header = regionElement.querySelector('div')
             const { x:xx, y:yy, width:ww, height:hh } = header.getBoundingClientRect()
             context.fillStyle = header.style.backgroundColor
-            context.fillRect(xx-columnContainerX, yy+deltaY, ww, hh)
+            context.fillRect(xx-deltaX, yy+deltaY, ww, hh)
         }
     }
 

--- a/js/roi/ROIManager.js
+++ b/js/roi/ROIManager.js
@@ -230,20 +230,20 @@ class ROIManager {
         return regionElement
     }
 
-    renderSVGContext(context, {deltaX, deltaY}) {
+    renderSVGContext(context, {deltaX, deltaY}, columnContainerX) {
 
         for (const regionElement of document.querySelectorAll('.igv-roi-region')) {
 
             // body
             const { x, y, width, height } = regionElement.getBoundingClientRect()
             context.fillStyle = regionElement.style.backgroundColor
-            context.fillRect(x+deltaX, y+deltaY, width, height)
+            context.fillRect(x-columnContainerX, y+deltaY, width, height)
 
             // header
             const header = regionElement.querySelector('div')
             const { x:xx, y:yy, width:ww, height:hh } = header.getBoundingClientRect()
             context.fillStyle = header.style.backgroundColor
-            context.fillRect(xx+deltaX, yy+deltaY, ww, hh)
+            context.fillRect(xx-columnContainerX, yy+deltaY, ww, hh)
         }
     }
 


### PR DESCRIPTION
Fix ROI shift issue when saving svg:

Issue:
When the IGV browser is not stick to the left of the web page, the saved SVG will have the ROI shifted:
how the IGV place in the webpage:
![Screenshot 2023-12-12 122912](https://github.com/igvteam/igv.js/assets/103169735/0673da05-309e-4b62-b439-12933b87d103)
the output SVG from IGV:
![Screenshot 2023-12-12 122941](https://github.com/igvteam/igv.js/assets/103169735/ab69750d-c32d-4827-ab00-4a8829bca237)

If the IGV browser is stick to the left of the webpage like this👇, then the ROI in SVG will be normal
![Screenshot 2023-12-12 163438](https://github.com/igvteam/igv.js/assets/103169735/28863955-6386-4b04-9129-53e323d40f08)


Work around:
Minus the columnContainer's clientX when rendering SVG rect of ROI instead of just using the regionElement's clientX