### PR TITLE
Minor fixes ROI and WIG track

### DIFF
--- a/js/feature/wigTrack.js
+++ b/js/feature/wigTrack.js
@@ -257,7 +257,8 @@ class WigTrack extends TrackBase {
 
                 // If the track includes negative values draw a baseline
                 if (this.dataRange.min < 0) {
-                    const basepx = (this.dataRange.max / (this.dataRange.max - this.dataRange.min)) * options.pixelHeight
+                    const ratio = this.dataRange.max / (this.dataRange.max - this.dataRange.min)
+                    const basepx = this.flipAxis ? (1 - ratio) * options.pixelHeight : ratio * options.pixelHeight
                     IGVGraphics.strokeLine(ctx, 0, basepx, options.pixelWidth, basepx, {strokeStyle: this.baselineColor})
                 }
             }

--- a/js/roi/ROIManager.js
+++ b/js/roi/ROIManager.js
@@ -349,9 +349,10 @@ function createSelector(regionKey) {
 }
 
 function parseRegionKey(regionKey) {
-    let [chr, ss, ee] = regionKey.split('-')
-    ss = parseInt(ss)
-    ee = parseInt(ee)
+    let regionParts = regionKey.split('-')
+    let ee = parseInt(regionParts.pop())
+    let ss = parseInt(regionParts.pop())
+    let chr = regionParts.join('-')
 
     return {chr, start: ss, end: ee, locus: `${chr}:${ss}-${ee}`, bedRecord: `${chr}\t${ss}\t${ee}`}
 }


### PR DESCRIPTION
Fixed two minor bugs related to ROI and WIG tracks:

### ROI
When adding custom ROI and trying to name it or switch to it the coordinates were not calculated properly for contigs with - (hyphen) in their name. 
  **Example**: If we have _contig-example01-123-156_ the split will take _contig_ as the contig name and try to convert _example01_ to int for the starting locus.

Fixed by taking the last two elements of the split results as start and end and joining the rest with - and taking the result of that as a contig name.

### WIG (and Merged track)
There is a baseline drawn when there are negative values in WIG file(s). This baseline was not taking flip y-axis into consideration i.e. it was not being moved to a new position of 0 on Y axis.

Fixed by subtracting the ratio of height from 1 in case of a flipped Y axis.

---

Sorry for putting ROI and WIG related fixes in a single pull request but they seemed like minor fixes so I did not want to overcomplicate it.