### PR TITLE
Merged track fixes/improvements

### DIFF
--- a/js/feature/mergedTrack.js
+++ b/js/feature/mergedTrack.js
@@ -132,12 +132,20 @@ class MergedTrack extends TrackBase {
 
     /**
      * Returns a MergedFeatureCollection containing an array of features for the specified range, 1 for each track.
+     * In addition it contains track names in the same order.
      */
     async getFeatures(chr, bpStart, bpEnd, bpPerPixel) {
-
+        
         const promises = this.tracks.map((t) => t.getFeatures(chr, bpStart, bpEnd, bpPerPixel))
         const featureArrays = await Promise.all(promises)
-        return new MergedFeatureCollection(featureArrays)
+        
+        if (featureArrays.every((arr) => arr.length === 0)){
+            return new MergedFeatureCollection([], [])
+        }
+        else {
+            const trackNames = this.tracks.map((t) => t.name)
+            return new MergedFeatureCollection(featureArrays, trackNames)
+        }
     }
 
     draw(options) {
@@ -162,20 +170,36 @@ class MergedTrack extends TrackBase {
 
     popupData(clickState) {
 
-        if (clickState.viewport && clickState.viewport.cachedFeatures) {
+        const clickedFeaturesArray = this.clickedFeatures(clickState)
 
-            const featuresArray = clickState.viewport.cachedFeatures.featureArrays
-
-            if (featuresArray && featuresArray.length === this.tracks.length) {
-                // Array of feature arrays, 1 for each track
-                const popupData = []
-                for (let i = 0; i < this.tracks.length; i++) {
-                    if (i > 0) popupData.push('<hr/>')
-                    popupData.push(`<div style=background-color:rgb(245,245,245);border-bottom-style:dashed;border-bottom-width:1px;padding-bottom:5px;padding-top:10px;font-weight:bold;font-size:larger >${this.tracks[i].name}</div>`)
-                    const trackPopupData = this.tracks[i].popupData(clickState, featuresArray[i])
+        if (clickedFeaturesArray && clickedFeaturesArray.length === this.tracks.length) {
+            // Array of feature arrays, 1 for each track
+            const popupData = []
+            // Flag used to check if there is at least one track with data
+            let noData = true
+            for (let i = 0; i < clickedFeaturesArray.length; i++) {
+                
+                
+                if (i > 0) popupData.push('<hr/>')
+                popupData.push(`<div style=background-color:rgb(245,245,245);border-bottom-style:dashed;border-bottom-width:1px;padding-bottom:5px;padding-top:10px;font-weight:bold;font-size:larger >${clickedFeaturesArray[i].trackName}</div>`)
+                if (clickedFeaturesArray[i].features.length > 0) {
+                    noData = false
+                    
+                    const trackPopupData = this.tracks[i].popupData(clickState, clickedFeaturesArray[i].features)
                     popupData.push(...trackPopupData)
-
                 }
+                else {
+                    // Notify user if there is no data or all values are 0 for a specific track
+                    popupData.push("Missing or 0 value(s)")
+                }
+            }
+
+            // We don't want to display popup if no track has data. 
+            // If at least one does, we want to display the popup.
+            if (noData === true) {
+                return []
+            }
+            else {
                 return popupData
             }
         }
@@ -188,22 +212,25 @@ class MergedTrack extends TrackBase {
         // feature is not already loaded this won't work,  but the user wouldn't be mousing over it either.
         const mergedFeaturesCollection = clickState.viewport.cachedFeatures
 
-        if (!mergedFeaturesCollection) {
+        if (!mergedFeaturesCollection || !mergedFeaturesCollection.featureArrays || !Array.isArray(mergedFeaturesCollection.featureArrays) || mergedFeaturesCollection.featureArrays.length === 0) {
             return []
         }
 
         const genomicLocation = clickState.genomicLocation
         const clickedFeatures = []
-        for (let features of mergedFeaturesCollection.featureArrays) {
-            // When zoomed out we need some tolerance around genomicLocation
-            const tolerance = (clickState.referenceFrame.bpPerPixel > 0.2) ? 3 * clickState.referenceFrame.bpPerPixel : 0.2
-            const ss = genomicLocation - tolerance
-            const ee = genomicLocation + tolerance
-            const tmp = (FeatureUtils.findOverlapping(features, ss, ee))
-            for (let f of tmp) {
-                clickedFeatures.push(f)
-            }
+        
+        // When zoomed out we need some tolerance around genomicLocation
+        const tolerance = (clickState.referenceFrame.bpPerPixel > 0.2) ? 3 * clickState.referenceFrame.bpPerPixel : 0.2
+        const ss = genomicLocation - tolerance
+        const ee = genomicLocation + tolerance
+        for (let i = 0; i < mergedFeaturesCollection.featureArrays.length; i++){
+            const tmp = (FeatureUtils.findOverlapping(mergedFeaturesCollection.featureArrays[i], ss, ee))
+            clickedFeatures.push({
+                trackName: mergedFeaturesCollection.trackNames[i],
+                features: tmp
+            })
         }
+
         return clickedFeatures
     }
 
@@ -216,8 +243,9 @@ class MergedTrack extends TrackBase {
 
 class MergedFeatureCollection {
 
-    constructor(featureArrays) {
+    constructor(featureArrays, trackNames) {
         this.featureArrays = featureArrays
+        this.trackNames = trackNames
     }
 
     getMax(start, end) {

--- a/js/feature/mergedTrack.js
+++ b/js/feature/mergedTrack.js
@@ -263,7 +263,14 @@ class MergedFeatureCollection {
                 }
             }
         }
-        return max
+        // We can assume if max has not changed from -Number.MAX_VALUE that there
+        // are no values we can use to determine max value and we set it to 100.
+        if (max === -Number.MAX_VALUE) {
+            return 100
+        }
+        else {
+            return max
+        }
     }
 
     // Covers cases in which a track has negative values.


### PR DESCRIPTION
PR fixing issues in Merged track.

## Popup data on click
A number of things related to Merged track popup data have been fixed.

### Popup data showing all loaded points and not being focused on what the user clicked on
**Issue**: The popup data was showing all data points which were loaded and not just those the user clicked on i.e. the click on popup behaviour was not the same as it is in the individual WIG tracks. 

<img width="351" alt="Screenshot 2024-02-06 at 16 56 09" src="https://github.com/igvteam/igv.js/assets/125308248/5e3519c4-e5f7-45cc-aefc-ee9f88c06b0d">

As you can see in the screenshot above the list is so long that it cannot fit into the popup when the track is zoomed out. In the screenshot below you can see how it looked like when zoomed in to the individual level. The position I clicked on is 1500 and instead of showing just that value it shows a lot of values around it.
<img width="241" alt="Screenshot 2024-02-06 at 16 57 39" src="https://github.com/igvteam/igv.js/assets/125308248/7869a254-906e-4bd4-9085-1f0e2fd2fe49">

**Fix**: Fixed by applying the clickedFeatures function logic on Merged track and adding the track name to the features list to make sure we pair the features with the correct track name. New solution screenshots in the same order (and same click position) as above:
<img width="357" alt="Screenshot 2024-02-06 at 16 55 18" src="https://github.com/igvteam/igv.js/assets/125308248/8f851cff-3bea-49ea-a1dc-87cb383bf29e">
<img width="235" alt="Screenshot 2024-02-06 at 16 57 59" src="https://github.com/igvteam/igv.js/assets/125308248/41a21129-27b4-4fd1-93cc-730d4ab15b49">

### Popup being displayed when there is no data to display at all
**Issue**:
<img width="246" alt="Screenshot 2024-02-06 at 17 08 32" src="https://github.com/igvteam/igv.js/assets/125308248/d0bdd566-cb8b-49a9-8f8a-6eac0642c9b1">

**Fix**: Do not display popup when there is no data to show. The popup will be displayed if there is at least one track that has data in that position.
<img width="250" alt="Screenshot 2024-02-06 at 17 08 48" src="https://github.com/igvteam/igv.js/assets/125308248/50b30e98-9b6f-4b0e-b6d9-9bdc7419fa4f">

## Y axis values when autoscaling is on and no data is displayed
**Issue**:
When there is no data to display the maximum value was being set to -Number.MAX_VALUE.
<img width="598" alt="Screenshot 2024-02-06 at 16 58 33" src="https://github.com/igvteam/igv.js/assets/125308248/11867a65-7dce-4267-9bd8-0b3de991269c">
**Fix**:
If max value stays -Number.MAX_VALUE we set it to 100 to have 0 to 100 scale as we do in WIG tracks.
<img width="806" alt="Screenshot 2024-02-06 at 16 58 16" src="https://github.com/igvteam/igv.js/assets/125308248/2c3df2ee-46dd-4476-8b8a-f19dec0c9792">


## 