### PR TITLE
New Feature: Alignment Grouping

### DIFF
--- a/js/bam/alignmentUtils.js
+++ b/js/bam/alignmentUtils.js
@@ -119,5 +119,43 @@ function binarySearch(array, pred, min) {
     return hi
 }
 
+/**
+ * This function sorts alignments within an alignment row based on the provided options
+ * 
+ * @param {Object} options 
+ * @param {Array} packedAlignmentRows 
+ * @returns {Array}
+ * 
+ */
+function sortAlignmentRows(options, packedAlignmentRows, alignmentContainer) {
+    const newRows = []
+    const undefinedRow = []
+    for (let row of packedAlignmentRows) {
+        const alignment = row.findAlignment(options.position, options.sortAsPairs)
+        if (undefined !== alignment) {
+            newRows.push(row)
+        } else {
+            undefinedRow.push(row)
+        }
+    }
 
-export {canBePaired, pairAlignments, unpairAlignments, packAlignmentRows}
+    newRows.sort((rowA, rowB) => {
+        const direction = options.direction
+        const rowAValue = rowA.getSortValue(options, alignmentContainer)
+        const rowBValue = rowB.getSortValue(options, alignmentContainer)
+
+        if (rowBValue === undefined && rowBValue !== undefined) return 1
+        else if (rowAValue !== undefined && rowBValue === undefined) return -1
+
+        const i = rowAValue > rowBValue ? 1 : (rowAValue < rowBValue ? -1 : 0)
+        return true === direction ? i : -i
+    })
+
+    for (let row of undefinedRow) {
+        newRows.push(row)
+    }
+    
+    return newRows
+}
+
+export {canBePaired, pairAlignments, unpairAlignments, packAlignmentRows, sortAlignmentRows}

--- a/js/bam/bamAlignment.js
+++ b/js/bam/bamAlignment.js
@@ -343,6 +343,43 @@ class BamAlignment {
         return this.baseModificationSets
     }
 
+    // TODO: add group by Base
+    // TODO: add groupAsPairs
+    getGroupValue({ option, tag, groupAsPairs }) {
+        switch (option) {
+            case "STRAND":
+                return this.strand ? '+' : '-'
+            case "FIRST_IN_PAIR_STRAND":
+                if (this.isPaired()){
+                    if (this.isFirstOfPair()) {
+                        return this.strand ? '+' : '-'
+                    } else if (this.isSecondOfPair()) {
+                        return this.strand ? '-' : '+'
+                    } else {
+                        return
+                    }
+                }
+                else{
+                    return 
+                }
+            case "START":
+                return this.start
+            case "INSERT_SIZE":
+                return this.fragmentLength
+            case "MATE_CHR":
+                return this.mate ? this.mate.chr : undefined
+            case "MQ":
+                return this.mq
+            case "ALIGNED_READ_LENGTH":
+                return this.lengthOnRef
+            case "TAG": {
+                return this.tags()[tag]
+            }
+            default:
+                return
+        }
+    }
+
 }
 
 const EMPTY_SET = new Set()

--- a/js/bam/bamAlignmentRow.js
+++ b/js/bam/bamAlignmentRow.js
@@ -92,7 +92,7 @@ class BamAlignmentRow {
             case "GAP_SIZE":
                 return -alignment.gapSizeAt(position)
             case "MATE_CHR":
-                return alignment.mate
+                return alignment.mate ? alignment.mate.chr : Number.MAX_VALUE
             case "MQ":
                 return alignment.mq === undefined ? Number.MAX_VALUE : -alignment.mq
             case "ALIGNED_READ_LENGTH":
@@ -155,8 +155,6 @@ class BamAlignmentRow {
             return baseScore
         }
     }
-
-
 }
 
 export default BamAlignmentRow

--- a/js/bam/bamTrack.js
+++ b/js/bam/bamTrack.js
@@ -1415,10 +1415,13 @@ class AlignmentTrack {
             
             // If NONE reset grouping to empty state
             if (option === "NONE"){
-                newGroupObject = {}
+                this.parent.groupObject = {}
+            }
+            else{
+                this.parent.groupObject = newGroupObject
             }
             
-            this.parent.groupObject = newGroupObject
+            
 
             // We restart contentHeight as we add empty alignment rows for spacing
             viewport.trackView.checkContentHeight()


### PR DESCRIPTION
As far as I've seen this is something that has been asked for and I was in need of it as well so I gave it a run. Please let me know what you think and check below for the things I would need help with.

### What has been done
What is implemented in this PR is (what we can call) a first version of alignment grouping that does not cover all of the things but it should cover most of the needs and with your help we should be able to make it even better (I had trouble with some of the parts due to my limited knowledge about the library). 

New option has been added to the alignment track which can be provided as following:
```
name: "Name",
type: "alignment",
format: "bam",
url: "URL",
indexURL: "INDEXURL",
group: {
    option: 'STRAND'
}
```

Current options are: STRAND, FIRST_IN_PAIR_STRAND, START, INSERT_SIZE, MATE_CHR, MQ, ALIGNED_READ_LENGTH, TAG

Menu entries have been added to the alignment track popup covering all of these as well as NONE which clears the grouping. 

A dashed line separating the groups has been added as well.

### What is left to be done 

Ordered by priority (in my opinion)
- Tests (I am not really good with JS tests as Frontend is not my main focus, but I can give it a try, would appreciate help if possible)
- Showing group names in the corner of the alignment track
- Group as pairs or making the grouping aware of paired alignments when the View as pairs option is used
- Group by Base (if we think this is needed)

When it comes to Showing group names in the corner of the alignment track I would really appreciate some help, at least a commit showing me how to add any text on the alignment track (or some component over it) which will not be moved from the corner when I move the view using click drag as this is causing me issues when I just use fill text on the alignment track.

There is a TODO for all of these things in the respective files.

### Minor fixes
There were a couple other minor fixes (some of them typos) that were fixed during this feature implementation. In addition, selecting to show soft clipped bases now preserves sorting and or grouping that was already selected (it was completely resetting the view previously).

