### PR TITLE
Change prettyPrint for small numbers - see issue #1800

### DIFF
--- a/js/util/paintAxis.js
+++ b/js/util/paintAxis.js
@@ -49,8 +49,10 @@ function paintAxis(ctx, width, height, colorOrUndefined) {
             return number.toFixed()
         } else if (Math.abs(number) >= 1) {
             return number.toFixed(1)
-        } else {
+        } else if (Math.abs(number) >= 0.1) {
             return number.toFixed(2)
+        } else {
+            return number.toExponential(1)
         }
     }
 }


### PR DESCRIPTION
Change axis limit labelling so that small values (< 0.1) are displayed with exponential notation (e.g. "2.3e-3") instead of "0.00" as previously implemented.

This would fix #1800 