### PR TITLE
cnvpytor track update

### DIFF
--- a/js/cnvpytor/cnvpytorTrack.js
+++ b/js/cnvpytor/cnvpytorTrack.js
@@ -244,6 +244,8 @@ class CNVPytorTrack extends TrackBase {
                 object: $(checkBox),
                 click: async function binSizesHandler() {
                     this.bin_size = rd_bin
+                    // data loader image
+                    this.trackView.startSpinner()
 
                     await this.recreate_tracks(rd_bin)
                     this.clearCachedFeatures()
@@ -280,6 +282,9 @@ class CNVPytorTrack extends TrackBase {
                 object: $(checkBox),
                 click: async function cnvCallerHandler() {
                     this.cnv_caller = cnv_caller
+                    // data loader image
+                    this.trackView.startSpinner()
+
                     await this.recreate_tracks(this.bin_size)
                     this.clearCachedFeatures()
                     this.trackView.updateViews()
@@ -517,7 +522,12 @@ class CNVPytorTrack extends TrackBase {
             // if number >= 100, show whole number
             // if >= 1 show 1 significant digits
             // if <  1 show 2 significant digits
-
+            
+            // change the label for negative number to positive; For BAF likelihood section
+            if(number < 0){
+                return Math.abs(number)
+            }
+            
             if (number === 0) {
                 return "0"
             } else if (Math.abs(number) >= 10) {


### PR DESCRIPTION
The following updates have been made:

- Added a spinner image during the loading of a new bin size and cnv caller to enhance user experience.
- BAF Label: Negative numbers are now displayed as positive numbers. For example, the range 0 to -1 will now be displayed as 0 to 1.


Thank you,
Arijit