### PR TITLE
Guess Fasta `indexURL` from functions as well

### DIFF
--- a/test/testFasta.js
+++ b/test/testFasta.js
@@ -195,4 +195,61 @@ suite("testFasta", function () {
 
     })
 
+    test("guess indexFile based on indexURL", async function () {
+        const fasta = new FastaSequence({
+                indexFile: 'https://will-be-used-only-if-no-index-url',
+                indexURL: 'https://foo/bar',
+            }
+        )
+        assert.equal(
+            fasta.indexFile,
+            "https://foo/bar",
+            "`this.indexFile` should be the same as `ref.indexURL`, even when there is `ref.indexFile`"
+        )
+    })
+
+    test("guess indexFile based on indexFile", async function () {
+        const fasta = new FastaSequence({
+                indexFile: 'https://foo/bar'
+            }
+        )
+        assert.equal(
+            fasta.indexFile,
+            "https://foo/bar",
+            "`this.indexFile` should be the same as `ref.indexFile` if no `ref.indexURL`"
+        )
+    })
+
+    test("guess indexFile based on fastaURL", async function () {
+        const fastaString = new FastaSequence({
+                fastaURL: 'https://foo/bar'
+            }
+        )
+        assert.equal(
+            fastaString.indexFile,
+            "https://foo/bar.fai",
+            "`this.indexFile` is the same URL as `ref.fastaURL` + '.fai' extension"
+        )
+
+        const fastaThunk = new FastaSequence({
+                fastaURL: () => 'https://foo/bar'
+            }
+        )
+        assert.equal(
+            await fastaThunk.indexFile(),
+            "https://foo/bar.fai",
+            "`this.indexFile` produced from `ref.fastaURL` should be produced from resolved fastaURL string"
+        )
+
+        const fastaAsyncThunk = new FastaSequence({
+                fastaURL: () => Promise.resolve('https://foo/bar')
+            }
+        )
+        let fastaURL = await fastaAsyncThunk.indexFile()
+        assert.equal(
+            fastaURL,
+            "https://foo/bar.fai",
+            "`this.indexFile` produced from `ref.fastaURL` should be produced from resolved fastaURL string"
+        )
+    })
 })


### PR DESCRIPTION
Hi! Thank you again for an awesome project!

I found one bug. It's not exactly a bug, since it only occurs if you disobey the documentation. Documentation doesn't mention this, but I found that - thanks to `igvxhr` - I can provide async functions for any URL in the config. However, if I set `fastaURL` as a function and omit `indexURL` and `indexFile`, IGV.js generates a `(function() {}).fai` gibberish URL.

I understand this isn't a typical bug because the documentation doesn't mention using functions for `fastaURL`. And, I know you wanted to reconsider the whole idea of guessing that URL. However, I wanted to fix this for consistency with track URLs and to add tests, so if you decide to change this behavior, it's test covered.

Feel free to request changes to this PR.