### PR TITLE
Fix passing client_id to oauth token client

### DIFF
--- a/js/igv-create.js
+++ b/js/igv-create.js
@@ -59,7 +59,7 @@ async function createBrowser(parentDiv, config) {
     }
     if (config.clientId && (!GoogleAuth.isInitialized())) {
         await GoogleAuth.init({
-            clientId: config.clientId,
+            client_id: config.clientId,
             apiKey: config.apiKey,
             scope: 'https://www.googleapis.com/auth/userinfo.profile'
         })


### PR DESCRIPTION
This path is followed only when client_id is provided as part of
`igv.createBrowser`, so people using the web app have not experienced
this issue yet, because the web app initializes the client directly.
