### PR TITLE
Wait for tracks to be fully drawn before returning to caller

### DIFF
--- a/js/browser.js
+++ b/js/browser.js
@@ -733,7 +733,7 @@ class Browser {
 
         // The ruler and ideogram tracks are not explicitly loaded, but needs updated nonetheless.
         for (let rtv of this.trackViews.filter((tv) => tv.track.type === 'ruler' || tv.track.type === 'ideogram')) {
-            rtv.updateViews()
+            await rtv.updateViews()
         }
 
         // If any tracks are selected show the selectino buttons
@@ -1124,11 +1124,7 @@ class Browser {
 
         if (!newTrack.autoscaleGroup) {
             // Group autoscale will get updated later (as a group)
-            if (config.sync) {
-                await trackView.updateViews()
-            } else {
-                trackView.updateViews()
-            }
+            await trackView.updateViews()
         }
 
         if (typeof newTrack.hasSamples === 'function' && newTrack.hasSamples()) {

--- a/js/sample/sampleInfo.js
+++ b/js/sample/sampleInfo.js
@@ -51,10 +51,15 @@ class SampleInfo {
         this.sampleMappingDictionary = {}
         this.colorDictionary = {}
         this.attributeRangeLUT = {}
+        this.initialized = false
     }
 
     get attributeCount() {
         return this.attributeNames ? this.attributeNames.length : 0
+    }
+
+    isInitialized() {
+        return this.initialized
     }
 
     hasAttributes() {
@@ -95,6 +100,8 @@ class SampleInfo {
 
             }
         }
+
+        this.initialized = true
 
     }
 


### PR DESCRIPTION
Nice project! Thanks for sharing this (⌒‿⌒)

This PR fixes two things (the 2nd fix depends on the 1st fix, I can open a new PR if we decide to take the middleground).

The first is a regression on `TrackView#renderSVGContext` which errors out because of a missing `SampleInfo#isInitialized()`, I implemented it.

The second one is a more aggressive change. I will explain my reasoning below:

## Problem

I wanted to write a pipeline to automatically generate SVG without human intervention. However the current implementation does not wait for the tracks to be loaded before returning to the caller, so I have no reliable way to tell when should I take the SVG.

## Fix

I added `await`'s to the `updateViews()` call. Caller can decide whether they want blocking behavior by awaiting or floating the API Promise as a whole, I don't think we need this level of granularity because in this (load -> draw -> display) sequence, as a user I cannot think of a reason I have to know when is only the first step done.

I also removed the undocumented sync option, it is not used or mentioned anywhere and the current infrastructure made it impossible to change for ex. the ruler to sync. If we really want this level of customization I think an `async` option is better, by default we wait for the updates on these tracks to be done before resolving (which I think is a more natural behavior by common sense: an API that returns a Promise I would expect it to be done with everything before telling me "I'm done!" unless I say otherwise), and advanced users can selectively make some tracks update untracked (for perf reasons?).

Demo:
[Unpatched (built from 1e97a6d)](https://blob.yumechi.jp/pub/igvjs-pr/poc.html) <- This produces partial SVGs & unpredictable.
[Patched](https://blob.yumechi.jp/pub/igvjs-pr/poc-patched.html) <- This produces full SVG