### PR TITLE
fix broken TrackView#renderSVGContext

### DIFF
--- a/js/sample/sampleInfo.js
+++ b/js/sample/sampleInfo.js
@@ -51,10 +51,15 @@ class SampleInfo {
         this.sampleMappingDictionary = {}
         this.colorDictionary = {}
         this.attributeRangeLUT = {}
+        this.initialized = false
     }
 
     get attributeCount() {
         return this.attributeNames ? this.attributeNames.length : 0
+    }
+
+    isInitialized() {
+        return this.initialized
     }
 
     hasAttributes() {
@@ -95,6 +100,8 @@ class SampleInfo {
 
             }
         }
+
+        this.initialized = true
 
     }
 


### PR DESCRIPTION
picked from #1844 

There is a regression on TrackView#renderSVGContext which errors out because of a missing SampleInfo#isInitialized(), I implemented it.

CC: @jrobinso 