### PR TITLE
Browser: Add getTrackConfigs() method. Returns list of JSON strings

### DIFF
--- a/js/browser.js
+++ b/js/browser.js
@@ -1480,6 +1480,12 @@ class Browser {
             .map(track => track.config.url))
     }
 
+    getTrackConfigs() {
+        return new Set(this.tracks
+            .filter(track => track.config && StringUtils.isString(track.config.url))
+            .map(track => JSON.stringify(track.config)))
+    }
+
 
     /**
      * Set the track height globally for all tracks.  (Note: Its not clear why this is useful).


### PR DESCRIPTION
- This PR supports the fix to allow marking GTEx track menu tracks as selected/unselected.
- 