### PR TITLE
Fix Merged track popup bug

### DIFF
--- a/js/feature/mergedTrack.js
+++ b/js/feature/mergedTrack.js
@@ -227,7 +227,14 @@ class MergedTrack extends TrackBase {
 
         const promises = this.tracks.map((t) => t.getFeatures(chr, bpStart, bpEnd, bpPerPixel))
         const featureArrays = await Promise.all(promises)
-        return new MergedFeatureCollection(featureArrays)
+        
+        if (featureArrays.every((arr) => arr.length === 0)){
+            return new MergedFeatureCollection([], [])
+        }
+        else {
+            const trackNames = this.tracks.map((t) => t.name)
+            return new MergedFeatureCollection(featureArrays, trackNames)
+        }
     }
 
     draw(options) {
@@ -446,8 +453,11 @@ class MergedTrack extends TrackBase {
 
 class MergedFeatureCollection {
 
-    constructor(featureArrays) {
+    constructor(featureArrays,trackNames) {
         this.featureArrays = featureArrays
+        //trackNames is needed for the popup data to populate track names 
+        //preserving the order of the actual tracks
+        this.trackNames = trackNames
     }
 
     getMax(start, end) {


### PR DESCRIPTION
Hello! First of all, thanks for all the work you've been putting into igv.js and all the new releases!!

One thing I noticed is a small bug in Merged Track popup which prevents it from displaying (see the screenshots).

This was probably partly introduced by myself not highlighting why I added a new parameter (trackNames) to the MergedFeatureCollection class when I previously worked on this. You've probably deleted it while cleaning the code but it is important for the popup data as it is used to display track names in the order of the actual tracks in the popup. I've reintroduced it and added a comment that should hopefully make it clearer.

Let me know if this breaks anything I am missing to see.

<img width="423" alt="Screenshot 2024-08-08 at 14 18 34" src="https://github.com/user-attachments/assets/ba339d9c-61ff-4c55-b4ed-a46110193354">
<img width="531" alt="Screenshot 2024-08-08 at 14 18 13" src="https://github.com/user-attachments/assets/268dec97-8c22-42c6-b461-05808ce724ae">

Edit: another side thing, we should perhaps think about updating eslint to newer version and then updating the ecmaVersion as it complains about static class properties as it is now.