### PR TITLE
Fix htsget missing chrAliasTable and decoding header after data fetch

### DIFF
--- a/js/htsget/htsgetBamReader.js
+++ b/js/htsget/htsgetBamReader.js
@@ -44,8 +44,8 @@ class HtsgetBamReader extends HtsgetReader {
             const ba = BGZip.unbgzf(compressedData.buffer)
             this.header = BamUtils.decodeBamHeader(ba, this.genome)
             this.chrAliasTable = new Map()
-            for (let key of Object.keys(this.header.chrAliasTable)) {
-                this.chrAliasTable.set(key, this.header.chrAliasTable[key])
+            for (let name of this.header.chrNames) {
+                this.chrAliasTable.set(name, this.genome.getChromosomeName(name))
             }
         }
 
@@ -55,6 +55,7 @@ class HtsgetBamReader extends HtsgetReader {
 
         // BAM decoding
         const ba = BGZip.unbgzf(compressedData.buffer)
+        this.header = BamUtils.decodeBamHeader(ba, this.genome)
 
         const chrIdx = this.header.chrToIndex[chr]
         const alignmentContainer = new AlignmentContainer(chr, start, end, this.config)


### PR DESCRIPTION
Potential fix for issue [1870](https://github.com/igvteam/igv.js/issues/1870) reported.

- add statements back into `bamUtils.js` that were present prior to the breakage.
- re-evaluates the header after the full fetch of data, to ensure the offset is correct for decoding