### PR TITLE
Add log scale feature to negative values in WIG track

### DIFF
--- a/js/feature/wigTrack.js
+++ b/js/feature/wigTrack.js
@@ -184,12 +184,10 @@ class WigTrack extends TrackBase {
         const bpPerPixel = options.bpPerPixel
         const bpStart = options.bpStart
         const pixelWidth = options.pixelWidth
-        const pixelHeight = options.pixelHeight
+        const pixelHeight = options.pixelHeight - 1
         const bpEnd = bpStart + pixelWidth * bpPerPixel + 1
-        const posColor = this.color || DEFAULT_COLOR
-
-        let lastNegValue = 1
-        const scaleFactor = this.getScaleFactor(this.dataRange.min, this.dataRange.max, options.pixelHeight, this.logScale)
+        
+        const scaleFactor = this.getScaleFactor(this.dataRange.min, this.dataRange.max, pixelHeight, this.logScale)
         const yScale = (yValue) => this.logScale
             ? this.computeYPixelValueInLogScale(yValue, scaleFactor)
             : this.computeYPixelValue(yValue, scaleFactor)

--- a/js/feature/wigTrack.js
+++ b/js/feature/wigTrack.js
@@ -158,7 +158,9 @@ class WigTrack extends TrackBase {
 
     // TODO: refactor to igvUtils.js
     getScaleFactor(min, max, height, logScale) {
-        const scale = logScale ? height / (Math.log10(Math.abs(max) + 1) - (min < 0 ? -Math.log10(Math.abs(min) + 1) : Math.log10(min + 1))) : height / (max - min)
+        const minValue = (logScale === true) ? ((min < 0) ? -Math.log10(Math.abs(min) + 1) : Math.log10(Math.abs(min) + 1)) : min
+        const maxValue = (logScale === true) ? Math.log10(Math.abs(max) + 1) : max
+        const scale = height / (maxValue - minValue)
         return scale
     }
 
@@ -167,11 +169,13 @@ class WigTrack extends TrackBase {
     }
 
     computeYPixelValueInLogScale(yValue, yScaleFactor) {
-        const minValue = (this.logScale) ? -Math.log10(Math.abs(this.dataRange.min) + 1) : this.dataRange.min
-        const maxValue = (this.logScale) ? Math.log10(Math.abs(this.dataRange.max) + 1) : this.dataRange.max
+        let maxValue = this.dataRange.max
+        let minValue =  this.dataRange.min
+        minValue = (minValue < 0) ? -Math.log10(Math.abs(minValue) + 1) : Math.log10(Math.abs(minValue) + 1)
+        maxValue = (maxValue < 0) ? -Math.log10(Math.abs(maxValue) + 1) : Math.log10(Math.abs(maxValue) + 1)
         
         yValue = (yValue < 0) ? -Math.log10(Math.abs(yValue) +1) : Math.log10(yValue + 1)
-        return ((this.flipAxis ? (yValue - minValue) : ((maxValue - yValue) * yScaleFactor)))
+        return ((this.flipAxis ? (yValue - minValue) : (maxValue - yValue)) * yScaleFactor)
     }
 
     draw(options) {
@@ -242,7 +246,7 @@ class WigTrack extends TrackBase {
                         if (f.value > this.dataRange.max) {
                             IGVGraphics.fillRect(ctx, x, 0, width, 3, {fillStyle: this.overflowColor})
                         } else if (f.value < this.dataRange.min) {
-                            IGVGraphics.fillRect(ctx, x, pixelHeight - 3, width, 3, {fillStyle: this.overflowColor})
+                            IGVGraphics.fillRect(ctx, x, pixelHeight - 2, width, 3, {fillStyle: this.overflowColor})
                         }
 
                     }
@@ -252,8 +256,10 @@ class WigTrack extends TrackBase {
 
                 // If the track includes negative values draw a baseline
                 if (this.dataRange.min < 0) {
-                    const minValue = (this.logScale) ? -Math.log10(Math.abs(this.dataRange.min) + 1) : this.dataRange.min
-                    const maxValue = (this.logScale) ? Math.log10(Math.abs(this.dataRange.max) + 1) : this.dataRange.max
+                    let maxValue = this.dataRange.max
+                    let minValue =  this.dataRange.min
+                    minValue = (this.logScale === true) ? ((minValue < 0) ? -Math.log10(Math.abs(minValue) + 1) : Math.log10(Math.abs(minValue) + 1)) : minValue
+                    maxValue = (this.logScale === true) ? ((maxValue < 0) ? -Math.log10(Math.abs(maxValue) + 1) : Math.log10(Math.abs(maxValue) + 1)) : maxValue
                     const ratio = maxValue / (maxValue - minValue)
                     const basepx = this.flipAxis ? (1 - ratio) * pixelHeight : ratio * pixelHeight
                     IGVGraphics.strokeLine(ctx, 0, basepx, options.pixelWidth, basepx, {strokeStyle: this.baselineColor})

--- a/js/feature/wigTrack.js
+++ b/js/feature/wigTrack.js
@@ -158,7 +158,7 @@ class WigTrack extends TrackBase {
 
     // TODO: refactor to igvUtils.js
     getScaleFactor(min, max, height, logScale) {
-        const scale = logScale ? height / (Math.log10(max + 1) - (min < 0 ? -Math.log10(Math.abs(min) + 1) : Math.log10(min + 1))) : height / (max - min)
+        const scale = logScale ? height / (Math.log10(Math.abs(max) + 1) - (min < 0 ? -Math.log10(Math.abs(min) + 1) : Math.log10(min + 1))) : height / (max - min)
         return scale
     }
 


### PR DESCRIPTION
Hello!

Another PR related to WIG tracks, this time related to log scale and negative values. As I've seen this has not been covered yet in either the JS or desktop version with negative values just being represented as 0. In my mind it makes sense to do the same thing as with the positive values and just represent it "under the line" i.e. as a negative value. I hope this makes sense to you as well.

The result can be seen in the screenshots below. 

This first set represents a merged track with two bigwig files which have opposite values
Regular scale:
![Screenshot 2024-08-09 at 22 40 45](https://github.com/user-attachments/assets/90a7375b-4b75-4619-9f89-1d57d436dc1a)
Log scale:
![Screenshot 2024-08-09 at 22 19 05](https://github.com/user-attachments/assets/c55e237b-a198-4374-b814-02996eea6d31)

This one is a single bigwig file with positive and negative values in it
Regular scale:
![Screenshot 2024-08-09 at 22 40 32](https://github.com/user-attachments/assets/78f92454-0926-4968-91aa-e6ac240d740a)
Log scale:
![Screenshot 2024-08-09 at 22 40 24](https://github.com/user-attachments/assets/221e8ed6-b6b7-43b8-8a1d-0e3ae44e363d)

There was another minor fix related to accounting for y coordinates being 0 based which mostly influences the "line" style of the WIG track. Is there any reason for line not being documented? It was a bit buggy with the SVG output previously but with recent work on the saving to SVG it seems to be working fine. Maybe we could document it together with "points" and "bar"?
