### PR TITLE
Fixed bug in ROI top margin when ideogram and/or ruler are hidden

### DIFF
--- a/js/roi/ROIManager.js
+++ b/js/roi/ROIManager.js
@@ -24,13 +24,17 @@ class ROIManager {
             const [rectA, rectB] = tracks
                 .map(track => track.trackView.viewports[0].$viewport.get(0))
                 .map(element => getElementVerticalDimension(element))
-
+            
+            //Covers cases in which ruler and/or ideogram are hidden
+            const heightA = rectA ? rectA.height : 0
+            const heightB = rectB ? rectB.height : 0
+            
             const elements = browser.columnContainer.querySelectorAll('.igv-roi-region')
 
             const fudge = -0.5
             if (elements) {
                 for (const element of elements) {
-                    element.style.marginTop = `${rectA.height + rectB.height + fudge}px`
+                    element.style.marginTop = `${heightA + heightB + fudge}px`
                 }
 
             }


### PR DESCRIPTION
Hello a small bug fix which covers a scenario in which ideogram and/or ruler are hidden. ROIManager expects both of these when calculating the top margin but we can disable either of them in the config/options and that breaks the code.

![Screenshot 2024-08-20 at 14 37 27](https://github.com/user-attachments/assets/e4876919-1998-438f-9a21-e5181abcfc2f)
![Screenshot 2024-08-20 at 14 37 46](https://github.com/user-attachments/assets/7dbbfcb9-ab4f-43e3-aea4-f23cc143bdb2)

Fixed with only ideogram
![Screenshot 2024-08-20 at 14 51 20](https://github.com/user-attachments/assets/dfa8163e-79cf-4a73-8c80-275a637f4af8)

Fixed with only ruler
![Screenshot 2024-08-20 at 14 52 13](https://github.com/user-attachments/assets/74499606-ba5b-47e5-a12b-9d86046f2e69)

Fixed with no ruler and no ideogram
![Screenshot 2024-08-20 at 14 52 43](https://github.com/user-attachments/assets/8f4048e9-11b4-4514-b28f-38af82c3e32d)
