### PR TITLE
Fix ROI deletion feature

### DIFF
--- a/js/roi/ROIManager.js
+++ b/js/roi/ROIManager.js
@@ -274,6 +274,10 @@ class ROIManager {
         return this.roiSets.find(roiSet => true === roiSet.isUserDefined)
     }
 
+    deleteUserDefinedROISet(){
+        this.roiSets = this.roiSets.filter(roiSet => roiSet.isUserDefined !== true);
+    }
+    
     initializeUserDefinedROISet() {
 
         const config =

--- a/js/roi/ROIManager.js
+++ b/js/roi/ROIManager.js
@@ -289,14 +289,7 @@ class ROIManager {
     }
 
     async deleteRegionWithKey(regionKey, columnContainer) {
-
         columnContainer.querySelectorAll(createSelector(regionKey)).forEach(node => node.remove())
-
-        const {feature, set} = await this.findRegionWithKey(regionKey)
-
-        if (set) {
-            set.removeFeature(feature)
-        }
 
         const records = await this.getTableRecords()
 
@@ -305,23 +298,6 @@ class ROIManager {
             this.setROITableButtonVisibility(false)
         }
 
-    }
-
-    async findRegionWithKey(regionKey) {
-
-        const {chr, start, end} = parseRegionKey(regionKey)
-
-        for (let set of this.roiSets) {
-            const features = await set.getFeatures(chr, start, end)
-
-            for (let feature of features) {
-                if (feature.chr === chr && feature.start >= start && feature.end <= end) {
-                    return {feature, set}
-                }
-            }
-        }
-
-        return {feature: undefined, set: undefined}
     }
 
     toJSON() {

--- a/js/roi/ROIMenu.js
+++ b/js/roi/ROIMenu.js
@@ -109,8 +109,14 @@ class ROIMenu {
                 '<hr/>',
                 {
                     label: 'Delete',
-                    click: () => {
+                    click: async () => {
                         roiSet.removeFeature(feature)
+                        const userDefinedFeatures = await roiSet.getAllFeatures()
+                        
+                        // Delete user defined ROI Set if it is empty
+                        if (Object.keys(userDefinedFeatures).length === 0) {
+                            roiManager.deleteUserDefinedROISet()
+                        }
                         roiManager.deleteRegionWithKey(regionElement.dataset.region, columnContainer)
                         roiManager.repaintTable()
                     }

--- a/js/roi/ROIMenu.js
+++ b/js/roi/ROIMenu.js
@@ -110,6 +110,7 @@ class ROIMenu {
                 {
                     label: 'Delete',
                     click: () => {
+                        roiSet.removeFeature(feature)
                         this.browser.roiManager.deleteRegionWithKey(regionElement.dataset.region, this.browser.columnContainer)
                         this.browser.roiManager.repaintTable()
                     }

--- a/js/roi/ROIMenu.js
+++ b/js/roi/ROIMenu.js
@@ -111,8 +111,8 @@ class ROIMenu {
                     label: 'Delete',
                     click: () => {
                         roiSet.removeFeature(feature)
-                        this.browser.roiManager.deleteRegionWithKey(regionElement.dataset.region, this.browser.columnContainer)
-                        this.browser.roiManager.repaintTable()
+                        roiManager.deleteRegionWithKey(regionElement.dataset.region, columnContainer)
+                        roiManager.repaintTable()
                     }
                 }
             )

--- a/js/roi/ROISet.js
+++ b/js/roi/ROISet.js
@@ -184,6 +184,10 @@ class DynamicFeatureSource {
         if (this.featureMap[chr]) {
             const match = `${chr}-${start}-${end}`
             this.featureMap[chr] = this.featureMap[chr].filter(feature => match !== `${feature.chr}-${feature.start}-${feature.end}`)
+            // Check if featureMap for a specific chromosome is empty now and delete it if yes
+            if (this.featureMap[chr].length === 0) {
+                delete this.featureMap[chr];
+            }
         }
     }
 }


### PR DESCRIPTION
Hello, this PR fixes a bug related to deletion of (user defined) ROIs. As we've moved `roiSet` to the `menuItems` method of `ROIMenu` we can now directly delete the ROI in question as there was a bug in finding the exact ROI (and its set) a user selected. 

As can be seen in the video when a user defines a ROI over a ROI provided through config and then tries to delete it, the ROI provided through config gets deleted instead of the user defined one. In addition the ROI table was not being updated accordingly when a ROI is deleted.

https://github.com/user-attachments/assets/01fa0e01-1fac-4517-afae-59df281b42fd