### PR TITLE
BigWig track: Add none window Function

### DIFF
--- a/js/bigwig/bwReader.js
+++ b/js/bigwig/bwReader.js
@@ -91,7 +91,7 @@ class BWReader {
             // Select a biwig "zoom level" appropriate for the current resolution.
             const zoomLevelHeaders = await this.getZoomHeaders()
             let zoomLevelHeader = bpPerPixel ? zoomLevelForScale(bpPerPixel, zoomLevelHeaders) : undefined
-            if (zoomLevelHeader) {
+            if (zoomLevelHeader && windowFunction != "none") {
                 treeOffset = zoomLevelHeader.indexOffset
                 decodeFunction = decodeZoomData
             } else {

--- a/js/bigwig/bwSource.js
+++ b/js/bigwig/bwSource.js
@@ -31,7 +31,7 @@ class BWSource extends BaseFeatureSource {
 
     queryable = true
     #wgValues = {}
-    windowFunctions = ["mean", "min", "max"]
+    windowFunctions = ["mean", "min", "max", "none"]
 
     constructor(config, genome) {
         super(genome)


### PR DESCRIPTION
Hi All, 
We would like to add to igv.js a none window function. 

This functionality is available for wig source and in IGV desktop. IGV Desktop screenshot:

<img width="1353" alt="Screenshot 2024-10-06 at 10 11 33 PM" src="https://github.com/user-attachments/assets/bbb0a2f0-758d-4a76-aa78-750d463e7227">

Example from the example files: 

<img width="1713" alt="Screenshot 2024-10-06 at 10 16 38 PM" src="https://github.com/user-attachments/assets/6759b967-cf16-4fc8-a052-7da2dacc8b7b">





