### PR TITLE
1908 :  HtsgetReader should not send HTSGet ticket server headers in data server requests

### DIFF
--- a/js/htsget/htsgetReader.js
+++ b/js/htsget/htsgetReader.js
@@ -64,13 +64,7 @@ class HtsgetReader {
                 promiseArray.push(Promise.resolve(dataUriToBytes(urlData.url)))
 
             } else {
-
-                const options = buildOptions(this.config || {})
-
-                if (urlData.headers) {
-                    options.headers = Object.assign(options.headers || {}, urlData.headers)
-                }
-
+                const options = buildOptions({headers: urlData.headers || {}})
                 promiseArray.push(igvxhr.loadArrayBuffer(urlData.url, options))
             }
         }

--- a/js/htsget/htsgetReader.js
+++ b/js/htsget/htsgetReader.js
@@ -64,7 +64,7 @@ class HtsgetReader {
                 promiseArray.push(Promise.resolve(dataUriToBytes(urlData.url)))
 
             } else {
-                const options = buildOptions({headers: urlData.headers || {}})
+                const options = {headers: urlData.headers || {}}
                 promiseArray.push(igvxhr.loadArrayBuffer(urlData.url, options))
             }
         }


### PR DESCRIPTION
Fixes #1908 :  HtsgetReader should not send HTSGet ticket server headers in data server requests

HtsgetReader should not include ticket server config / headers in requests to the data server. See issue #1908 for further details.