### PR TITLE
fix none windowFunction for wig track in bedgraph format

### DIFF
--- a/js/feature/wigTrack.js
+++ b/js/feature/wigTrack.js
@@ -395,7 +395,7 @@ class WigTrack extends TrackBase {
  */
 function summarizeData(features, startBP, bpPerPixel, windowFunction = "mean") {
 
-    if (bpPerPixel <= 1 || !features || features.length === 0) {
+    if (bpPerPixel <= 1 || !features || features.length === 0 || windowFunction === "none") {
         return features
     }
 

--- a/test/testWig.js
+++ b/test/testWig.js
@@ -106,6 +106,9 @@ suite("testWig", function () {
         summarizedData = summarizeData(features, start, bpPerPixel, windowFunction)
         assert.equal(summarizedData.length, 953)
 
+        windowFunction = "none"
+        summarizedData = summarizeData(features, start, bpPerPixel, windowFunction)
+        assert.equal(summarizedData.length, 24546)
 
         // first bin
         // console.log(features[0].start)


### PR DESCRIPTION
Hello All,

https://github.com/igvteam/igv.js/pull/1899 added none window function for wig track. However, it doesn't work with bedgraph format with error about `Unkown window function: None` when selecting "all" chromosome

![image](https://github.com/user-attachments/assets/3dca3974-f178-4657-a48f-65a7b983b641)

This PR fixes it

![image](https://github.com/user-attachments/assets/d2dd75c7-f497-4aac-a6a8-7fad72b1a5b3)


