### PR TITLE
Bug fix for setting onlyHandleClicksForHighlightedSamples in gCNV track

### DIFF
--- a/js/gcnv/gcnvTrack.js
+++ b/js/gcnv/gcnvTrack.js
@@ -59,6 +59,11 @@ class GCNVTrack extends TrackBase {
                 this.config.samplesClickedToHighlight = {}
             }
 
+            // enables onlyHandleClicksForHighlightedSamples to be set from file header
+            if (this.header.hasOwnProperty("onlyHandleClicksForHighlightedSamples")) {
+                this.config.onlyHandleClicksForHighlightedSamples = true
+            }
+
             // Special track line properties
             if (this.header.hasOwnProperty("highlight")) {
                 this.config.highlightSamples = {}


### PR DESCRIPTION
## Summary

From [previous discussion](https://github.com/igvteam/igv.js/issues/1411), I remembered there being an option to disable pop up labels when clicking on non highlighted samples. This would be really useful where only a single highlighted sample is being displayed, but wanting to keep a full run of unlabelled and unhighlighted sample traces in grey to the background. I tried adding this to the bed file header but it did not seem to work.

I know this can be set via the track config when initialising the browser window, but this does not work when using things such as IGV web app for loading files.

Example header of file:
```
track type=gcnv height=500 onlyHandleClicksForHighlightedSamples=true highlight=sample_1;red highlight=mean;blue highlight=mean_plus_std;#0B2559 highlight=mean_minus_std;#0B2559 highlight=mean_plus_std2;#36BFB1 highlight=mean_minus_std2;#36BFB1
```

Example showing the unlabeled and unhighlighted samples are still visible on click:
![image](https://github.com/user-attachments/assets/9199cecb-eb1c-45ca-8587-8e00008f330d)


## Changes

- Added an additional check for `onlyHandleClicksForHighlightedSamples` being defined in bed file header line, and if present setting this to the config object

## Testing

Built locally with proposed changes and started up the test browser with `npx http-server`, loaded the test file and the behaviour is as expected. I have attached a minimal test bed of just chromosome X that I used for testing.

[test.gcnv.bed.gz](https://github.com/user-attachments/files/17814908/test.gcnv.bed.gz)

Example of it working:

https://github.com/user-attachments/assets/91049886-9710-40a8-aa74-283ba1dda4d8


