### PR TITLE
Precision option for slide dialog

### DIFF
--- a/js/ui/components/sliderDialog.js
+++ b/js/ui/components/sliderDialog.js
@@ -56,7 +56,7 @@ class SliderDialog {
         this._input.addEventListener('input', () => {
             const number = parseFloat(this._input.value)/this._scaleFactor
             this.callback(number)
-            this._output.value = `${number.toFixed(2)}`
+            this._output.value = `${number.toFixed(this._precision)}`
         }, false)
 
         this.ok.addEventListener('click', () => {
@@ -90,6 +90,7 @@ class SliderDialog {
         this.label.textContent = options.label
 
         this._scaleFactor = options.scaleFactor
+        this._precision = options.precision || 2 // added precision option with default value of 2
         const [ minS, maxS, valueS ] = [ options.min, options.max, options.value ].map(number => (Math.floor(this._scaleFactor * number)).toString())
 
         this._input.min = minS
@@ -99,7 +100,7 @@ class SliderDialog {
         const numer = parseFloat(valueS)
         const denom = this._scaleFactor
         const number = numer/denom
-        this._output.value = `${number.toFixed(2)}`
+        this._output.value = `${number.toFixed(this._precision)}`
 
         this.callback = options.callback || options.click
 


### PR DESCRIPTION
I have added a precision option in the slide dialog, allowing a track to set the desired decimal precision. By default, it is set to 2.
```
this._precision = options.precision || 2; // Added precision option with a default value of 2

```
Previously, the precision was fixed at 2:
```
this._output.value = `${number.toFixed(2)}`;
```
Now, it dynamically adjusts based on the specified precision:
```
this._output.value = `${number.toFixed(this._precision)}`;

```

Thank you,
Arijit