### PR TITLE
Add genomicLocation to the "trackclick" event

### DIFF
--- a/js/igv.d.ts
+++ b/js/igv.d.ts
@@ -528,6 +528,7 @@ export namespace BrowserEvents {
                 T extends "trackclick" ? (
                         track: Tracks.Track,
                         popoverData?: Record<string, string>,
+                        genomicLocation?: number
                     ) => EventReturn<T> :
                     T extends "trackorderchanged" ? (trackNames: string[]) => EventReturn<T> :
                         (payload: any) => EventReturn<T>;

--- a/js/igv.d.ts
+++ b/js/igv.d.ts
@@ -533,7 +533,7 @@ export namespace BrowserEvents {
                         (payload: any) => EventReturn<T>;
 
     export type EventReturn<T extends EventType> =
-        T extends "trackclick" ? boolean :
+        T extends "trackclick" ? string | boolean | undefined :
             void;
 }
 

--- a/js/trackViewport.js
+++ b/js/trackViewport.js
@@ -920,7 +920,7 @@ class TrackViewport extends Viewport {
         let track = this.trackView.track
         const dataList = track.popupData(clickState)
 
-        const popupClickHandlerResult = this.browser.fireEvent('trackclick', [track, dataList])
+        const popupClickHandlerResult = this.browser.fireEvent('trackclick', [track, dataList, clickState.genomicLocation])
 
         let content
         if (undefined === popupClickHandlerResult || true === popupClickHandlerResult) {


### PR DESCRIPTION
Hello! A small PR aimed at the trackclick event and data available in the handler: **genomicLocation** has been added to the event handler for the **trackclick** event.

The reasoning behind this was mainly aimed at the bigwig tracks which can have a location range in the popup even though we click on a single location (a bigwig file can have ranges in it for example 100-200 23). I thought it might be useful having the exact location where the user clicked as this might be used in the handler itself. The new field was added as optional so we do not raise typing issues with current implementations users of igv.js might have. We could add the whole clickState as well but it seems to me that it would be an overkill.

Another fix I did while working on the above is related to the EvenReturn type for trackclick event. For this one I guess it was only boolean at some point and was not changed once string was allowed in the popup function.

As always, feel free to reject this one if you don't find this change useful. 