### PR TITLE
Update genomes.json BACKUP_URL

### DIFF
--- a/js/genome/genomeUtils.js
+++ b/js/genome/genomeUtils.js
@@ -3,7 +3,7 @@ import {convertToHubURL} from "../ucsc/ucscUtils.js"
 import {loadHub} from "../ucsc/hub/hubParser.js"
 
 const DEFAULT_GENOMES_URL = "https://igv.org/genomes/genomes.json"
-const BACKUP_GENOMES_URL = "https://raw.githubusercontent.com/igvteam/igv-genomes/refs/heads/main/dist/genomes.json"
+const BACKUP_GENOMES_URL = "https://raw.githubusercontent.com/igvteam/igv-data/main/genomes/web/genomes.json"
 
 const GenomeUtils = {
 


### PR DESCRIPTION
We are having some intermittent issues with the `genomes.json` file from `igv.js` at the moment in Stockholm. A directly configured `genomeList` works fine with `loadDefaultGenomes: false`, but while investigating, it was noticed that the references repo directory structure has been rearranged a bit, so the `igv.js` `BACKUP_GENOMES_URL` is off. It looks like the current live one is `https://raw.githubusercontent.com/igvteam/igv-data/main/genomes/web/genomes.json`.
Or should we be using something like https://s3.us-east-1.amazonaws.com/igv.org.genomes/genomes.json instead?
