### PR TITLE
Bug fix: Variable naming conflict in `hubParser.js`

### DIFF
--- a/js/ucsc/hub/hubParser.js
+++ b/js/ucsc/hub/hubParser.js
@@ -136,9 +136,9 @@ async function loadStanzas(url) {
             }
 
 
-            const i = line.indexOf(' ')
-            const key = line.substring(0, i).trim()
-            let value = line.substring(i + 1).trim()
+            const index = line.indexOf(' ')
+            const key = line.substring(0, index).trim()
+            let value = line.substring(index + 1).trim()
 
             if (key === "type") {
                 // The "type" property contains format and sometimes other information. For example, data range


### PR DESCRIPTION
Full details in this issue:
- https://github.com/igvteam/igv.js/issues/2006

Changes:
- Rename duped variable `i` to `index` to fix naming conflict