### PR TITLE
Add dynseq track support

### DIFF
--- a/examples/dynseq-example.html
+++ b/examples/dynseq-example.html
@@ -1,0 +1,179 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, shrink-to-fit=no"
+    />
+    <title>IGV.js - Dynamic Sequence Track Example</title>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.jsdelivr.net/npm/bootstrap@4.4.1/dist/css/bootstrap.min.css"
+    />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.jsdelivr.net/npm/igv@2.15.8/dist/igv.min.css"
+    />
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 20px;
+      }
+      .container {
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+      #igv-div {
+        border: 1px solid #ccc;
+        margin: 20px 0;
+      }
+      .description {
+        background-color: #f8f9fa;
+        padding: 15px;
+        border-radius: 5px;
+        margin-bottom: 20px;
+      }
+      .code-block {
+        background-color: #f8f9fa;
+        padding: 10px;
+        border-radius: 5px;
+        font-family: monospace;
+        font-size: 0.9em;
+        margin: 10px 0;
+      }
+    </style>
+  </head>
+
+  <body>
+    <div class="container">
+      <h1>IGV.js - Dynamic Sequence Track Example</h1>
+
+      <div class="description">
+        <h3>Dynamic Sequence (DynSeq) Track</h3>
+        <p>
+          This example demonstrates the new <strong>dynseq</strong> graph type
+          for WIG tracks. The dynseq option renders genome bases as colored
+          glyphs with heights proportional to the WIG values, combining sequence
+          information with quantitative data.
+        </p>
+
+        <h4>Features:</h4>
+        <ul>
+          <li>
+            Genome bases are rendered as colored rectangles (A=green, T=red,
+            G=orange, C=blue)
+          </li>
+          <li>
+            Height of each base glyph corresponds to the WIG value at that
+            position
+          </li>
+          <li>Base letters are displayed when zoomed in sufficiently</li>
+          <li>Overflow indicators show when values exceed the data range</li>
+          <li>
+            Compatible with all existing WIG track options (autoscale, data
+            range, etc.)
+          </li>
+        </ul>
+
+        <h4>Usage:</h4>
+        <div class="code-block">
+          Set <code>graphType: "dynseq"</code> in your WIG track configuration,
+          or select "dynseq" from the track's context menu.
+        </div>
+      </div>
+
+      <div id="igv-div"></div>
+
+      <div class="description">
+        <h4>Track Configuration Example:</h4>
+        <pre class="code-block">
+{
+  "name": "Sample DynSeq Track",
+  "type": "wig",
+  "format": "bedgraph",
+  "url": "path/to/your/data.bedgraph",
+  "graphType": "dynseq",
+  "height": 100,
+  "color": "blue",
+  "altColor": "red"
+}</pre
+        >
+      </div>
+    </div>
+
+    <script src="../dist/igv.min.js"></script>
+    <script type="module">
+      //   import igv from "../dist/igv.esm.min.js";
+
+      document.addEventListener("DOMContentLoaded", function () {
+        var igvDiv = document.getElementById("igv-div");
+
+        // Create a simple BedGraph data URL for demonstration (including negative values)
+        var sampleBedGraphData = `track type=bedGraph name="Sample DynSeq Data" description="Dynamic sequence track example"
+chr1	1000	1010	2.5
+chr1	1010	1020	4.2
+chr1	1020	1030	-1.8
+chr1	1030	1040	3.7
+chr1	1040	1050	5.1
+chr1	1050	1060	-2.3
+chr1	1060	1070	4.8
+chr1	1070	1080	-1.9
+chr1	1080	1090	3.4
+chr1	1090	1100	4.6
+chr1	1100	1110	-2.1
+chr1	1110	1120	3.9
+chr1	1120	1130	5.3
+chr1	1130	1140	-1.7
+chr1	1140	1150	4.4
+chr1	1150	1160	-2.8
+chr1	1160	1170	3.2
+chr1	1170	1180	4.9
+chr1	1180	1190	-1.5
+chr1	1190	1200	3.8`;
+
+        var bedGraphDataUri =
+          "data:text/plain;base64," + btoa(sampleBedGraphData);
+
+        var options = {
+          genome: "hg38",
+          locus: "chr1:119,734-119,809",
+          tracks: [
+            {
+              name: "Standard Bar Chart",
+              type: "wig",
+              url: "https://www.encodeproject.org/files/ENCFF105JTF/@@download/ENCFF105JTF.bigWig",
+              graphType: "bar",
+              height: 60,
+              color: "blue",
+              altColor: "red",
+            },
+            {
+              name: "Dynamic Sequence Track",
+              type: "wig",
+              url: "https://www.encodeproject.org/files/ENCFF105JTF/@@download/ENCFF105JTF.bigWig",
+              graphType: "dynseq",
+              height: 80,
+              color: "blue",
+              altColor: "red",
+            },
+          ],
+        };
+
+        igv
+          .createBrowser(igvDiv, options)
+          .then(function (browser) {
+            console.log("IGV browser created successfully");
+            console.log(
+              "Try right-clicking on the DynSeq track to switch between graph types"
+            );
+          })
+          .catch(function (error) {
+            console.error("Error creating IGV browser:", error);
+          });
+      });
+    </script>
+  </body>
+</html>

--- a/examples/dynseq-example.html
+++ b/examples/dynseq-example.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1, shrink-to-fit=no"
     />
-    <title>IGV.js - Dynamic Sequence Track Example</title>
+    <title>IGV.js - DynSeq Track Example</title>
     <link
       rel="stylesheet"
       type="text/css"
@@ -49,14 +49,14 @@
 
   <body>
     <div class="container">
-      <h1>IGV.js - Dynamic Sequence Track Example</h1>
+      <h1>IGV.js - DynSeq Track Example</h1>
 
       <div class="description">
         <h3>Dynamic Sequence (DynSeq) Track</h3>
         <p>
-          This example demonstrates the new <strong>dynseq</strong> graph type
-          for WIG tracks. The dynseq option renders genome bases as colored
-          glyphs with heights proportional to the WIG values, combining sequence
+          This example demonstrates the <strong>dynseq</strong> graph type for
+          WIG tracks. The dynseq option renders genome bases as colored glyphs
+          with heights proportional to the WIG values, combining sequence
           information with quantitative data.
         </p>
 
@@ -93,8 +93,7 @@
 {
   "name": "Sample DynSeq Track",
   "type": "wig",
-  "format": "bedgraph",
-  "url": "path/to/your/data.bedgraph",
+  "url": "path/to/your/data.bigWig",
   "graphType": "dynseq",
   "height": 100,
   "color": "blue",

--- a/examples/dynseq-example.html
+++ b/examples/dynseq-example.html
@@ -104,38 +104,11 @@
       </div>
     </div>
 
-    <script src="../dist/igv.min.js"></script>
     <script type="module">
-      //   import igv from "../dist/igv.esm.min.js";
+      import igv from "../dist/igv.esm.min.js";
 
       document.addEventListener("DOMContentLoaded", function () {
         var igvDiv = document.getElementById("igv-div");
-
-        // Create a simple BedGraph data URL for demonstration (including negative values)
-        var sampleBedGraphData = `track type=bedGraph name="Sample DynSeq Data" description="Dynamic sequence track example"
-chr1	1000	1010	2.5
-chr1	1010	1020	4.2
-chr1	1020	1030	-1.8
-chr1	1030	1040	3.7
-chr1	1040	1050	5.1
-chr1	1050	1060	-2.3
-chr1	1060	1070	4.8
-chr1	1070	1080	-1.9
-chr1	1080	1090	3.4
-chr1	1090	1100	4.6
-chr1	1100	1110	-2.1
-chr1	1110	1120	3.9
-chr1	1120	1130	5.3
-chr1	1130	1140	-1.7
-chr1	1140	1150	4.4
-chr1	1150	1160	-2.8
-chr1	1160	1170	3.2
-chr1	1170	1180	4.9
-chr1	1180	1190	-1.5
-chr1	1190	1200	3.8`;
-
-        var bedGraphDataUri =
-          "data:text/plain;base64," + btoa(sampleBedGraphData);
 
         var options = {
           genome: "hg38",
@@ -145,7 +118,6 @@ chr1	1190	1200	3.8`;
               name: "Standard Bar Chart",
               type: "wig",
               url: "https://www.encodeproject.org/files/ENCFF105JTF/@@download/ENCFF105JTF.bigWig",
-              graphType: "bar",
               height: 60,
               color: "blue",
               altColor: "red",

--- a/examples/dynseq-example.html
+++ b/examples/dynseq-example.html
@@ -71,11 +71,6 @@
             position
           </li>
           <li>Base letters are displayed when zoomed in sufficiently</li>
-          <li>Overflow indicators show when values exceed the data range</li>
-          <li>
-            Compatible with all existing WIG track options (autoscale, data
-            range, etc.)
-          </li>
         </ul>
 
         <h4>Usage:</h4>

--- a/js/feature/wigTrack.js
+++ b/js/feature/wigTrack.js
@@ -127,7 +127,7 @@ class WigTrack extends TrackBase {
                 try {
                     f.sequence = await this.browser.genome.getSequence(f.chr, Math.floor(f.start), Math.floor(f.end))
                 } catch (error) {
-                    console.warn('Failed to get sequence for feature:', error)
+                    console.warn(`Failed to get sequence for feature at chr: ${f.chr}, start: ${f.start}, end: ${f.end}. Error:`, error)
                     f.sequence = null
                 }
             }

--- a/test/testDynseq.js
+++ b/test/testDynseq.js
@@ -1,0 +1,229 @@
+import "./utils/mockObjects.js"
+import {assert} from 'chai'
+import WigTrack from "../js/feature/wigTrack.js"
+import {createGenome} from "./utils/MockGenome.js"
+import {defaultNucleotideColors} from "../js/util/nucleotideColors.js"
+
+const genome = createGenome()
+
+suite("testDynseq", function () {
+
+    // Enhanced mock browser object with nucleotide colors
+    const browser = {
+        genome,
+        nucleotideColors: defaultNucleotideColors,
+        on: () => {},
+        off: () => {},
+        columnContainer: {
+            appendChild: () => {}
+        }
+    }
+
+    test("dynseq graphType option in menu", async function () {
+        const config = {
+            format: 'bedgraph',
+            url: 'test/data/wig/allPositive.bedgraph',
+            graphType: 'dynseq'
+        }
+        const track = new WigTrack(config, browser)
+        await track.postInit()
+
+        // Test that dynseq is included in the supported graph types
+        const supportedTypes = ['bar', 'line', 'points', 'heatmap', 'dynseq']
+        assert.include(supportedTypes, track.graphType)
+    })
+
+    test("dynseq track configuration", async function () {
+        const config = {
+            format: 'bedgraph',
+            url: 'test/data/wig/allPositive.bedgraph',
+            graphType: 'dynseq',
+            height: 100
+        }
+        const track = new WigTrack(config, browser)
+        await track.postInit()
+
+        assert.equal(track.graphType, 'dynseq')
+        assert.equal(track.height, 100)
+    })
+
+    test("dynseq track state serialization", async function () {
+        const config = {
+            format: 'bedgraph',
+            url: 'test/data/wig/allPositive.bedgraph',
+            graphType: 'dynseq'
+        }
+        const track = new WigTrack(config, browser)
+        await track.postInit()
+
+        const state = track.getState()
+        assert.equal(state.graphType, 'dynseq')
+    })
+
+    test("dynseq sequence data attachment", async function () {
+        // Test the sequence attachment logic directly
+        const config = {
+            format: 'bedgraph',
+            url: 'test/data/wig/allPositive.bedgraph',
+            graphType: 'dynseq'
+        }
+        const track = new WigTrack(config, browser)
+        await track.postInit()
+
+        // Mock feature with sequence data
+        const mockFeature = {
+            chr: 'chr1',
+            start: 1000,
+            end: 1010,
+            value: 2.5,
+            sequence: 'ATCGATCGAT'
+        }
+
+        // Test that features can have sequence data attached
+        assert.property(mockFeature, 'sequence')
+        assert.isString(mockFeature.sequence)
+        assert.match(mockFeature.sequence, /^[ATCGN]*$/)
+        assert.equal(mockFeature.sequence.length, 10)
+    })
+
+    test("dynseq SVG path parser", async function () {
+        const config = {
+            format: 'bedgraph',
+            url: 'test/data/wig/allPositive.bedgraph',
+            graphType: 'dynseq'
+        }
+        const track = new WigTrack(config, browser)
+        await track.postInit()
+
+        // Mock canvas context
+        const mockContext = {
+            beginPath: () => {},
+            moveTo: () => {},
+            lineTo: () => {},
+            bezierCurveTo: () => {},
+            closePath: () => {},
+            fill: () => {}
+        }
+
+        // Test SVG path parsing with different path types
+        const pathsToTest = [
+            'M 0 0 L 100 100',  // Move and line
+            'M 0 0 C 25 0 75 100 100 100',  // Move and cubic bezier
+            'M 0 100 L 33 0 L 66 0 L 100 100'  // Multiple lines
+        ]
+
+        for (const path of pathsToTest) {
+            // This should not throw an error
+            assert.doesNotThrow(() => {
+                track.drawSVGPath(mockContext, path, 0, 0, 100, 100)
+            })
+        }
+    })
+
+    test("dynseq letter glyph rendering", async function () {
+        const config = {
+            format: 'bedgraph',
+            url: 'test/data/wig/allPositive.bedgraph',
+            graphType: 'dynseq'
+        }
+        const track = new WigTrack(config, browser)
+        await track.postInit()
+
+        // Mock canvas context
+        const mockContext = {
+            save: () => {},
+            restore: () => {},
+            translate: () => {},
+            scale: () => {},
+            beginPath: () => {},
+            moveTo: () => {},
+            lineTo: () => {},
+            bezierCurveTo: () => {},
+            closePath: () => {},
+            fill: () => {},
+            fillStyle: ''
+        }
+
+        // Test drawing each nucleotide
+        const nucleotides = ['A', 'T', 'G', 'C', 'N']
+        for (const base of nucleotides) {
+            // Should not throw error
+            assert.doesNotThrow(() => {
+                track.drawLetterGlyph(mockContext, base, 0, 0, 50, 50, 'red', false)
+            })
+        }
+    })
+
+    test("dynseq vertical flipping for negative values", async function () {
+        const config = {
+            format: 'bedgraph',
+            url: 'test/data/wig/mixedPosNeg.bedgraph',
+            graphType: 'dynseq'
+        }
+        const track = new WigTrack(config, browser)
+        await track.postInit()
+
+        // Mock canvas context to track transformations
+        let scaleYCall = null
+        const mockContext = {
+            save: () => {},
+            restore: () => {},
+            translate: () => {},
+            scale: (x, y) => { scaleYCall = y },
+            beginPath: () => {},
+            moveTo: () => {},
+            lineTo: () => {},
+            bezierCurveTo: () => {},
+            closePath: () => {},
+            fill: () => {},
+            fillStyle: ''
+        }
+
+        // Test positive value (should not flip)
+        track.drawLetterGlyph(mockContext, 'A', 0, 0, 50, 50, 'red', false)
+        assert.notEqual(scaleYCall, -1)
+
+        // Test negative value (should flip)
+        scaleYCall = null
+        track.drawLetterGlyph(mockContext, 'A', 0, 0, 50, 50, 'red', true)
+        assert.equal(scaleYCall, -1)
+    })
+
+    test("dynseq renders with mixed positive/negative values", async function () {
+        const config = {
+            format: 'bedgraph',
+            url: 'test/data/wig/mixedPosNeg.bedgraph',
+            graphType: 'dynseq'
+        }
+        const track = new WigTrack(config, browser)
+        await track.postInit()
+
+        // Test that the track correctly identifies positive and negative values
+        const positiveFeature = { value: 2.5, sequence: 'ATCG' }
+        const negativeFeature = { value: -1.8, sequence: 'GCTA' }
+        
+        // Test that we can distinguish between positive and negative values
+        assert.isTrue(positiveFeature.value > 0)
+        assert.isTrue(negativeFeature.value < 0)
+        
+        // Test that both features have valid sequence data
+        assert.isString(positiveFeature.sequence)
+        assert.isString(negativeFeature.sequence)
+        assert.match(positiveFeature.sequence, /^[ATCGN]*$/)
+        assert.match(negativeFeature.sequence, /^[ATCGN]*$/)
+    })
+
+    test("dynseq menu items include dynseq option", async function () {
+        const config = {
+            format: 'bedgraph',
+            url: 'test/data/wig/allPositive.bedgraph'
+        }
+        const track = new WigTrack(config, browser)
+        await track.postInit()
+
+        // Test that dynseq is in the list of supported graph types
+        const supportedTypes = ['bar', 'line', 'points', 'heatmap', 'dynseq']
+        assert.include(supportedTypes, 'dynseq', 'dynseq should be in supported graph types')
+    })
+
+})


### PR DESCRIPTION
Dynseq track information: https://kundajelab.github.io/dynseq-pages/

Example page:
<img width="960" height="873" alt="Screenshot 2025-07-18 at 2 14 02 PM" src="https://github.com/user-attachments/assets/a2defc92-2d7d-499c-af4b-900ce3f6573c" />

Dynseq zooming scales letters, and switches to standard bar chart when sufficiently zoomed out:
https://github.com/user-attachments/assets/bc92d097-848b-47e4-9476-8c9970a88441

Dynseq in context menu:
<img width="1268" height="595" alt="Screenshot 2025-07-18 at 2 04 35 PM" src="https://github.com/user-attachments/assets/7ac2c980-85e8-4ebf-a524-68d8bb03abb2" />
