### PR TITLE
Fix condition for multiWig container check

### DIFF
--- a/js/ucsc/hub/trackDbHub.js
+++ b/js/ucsc/hub/trackDbHub.js
@@ -71,7 +71,7 @@ class TrackDbHub {
 
                 const isContainer = (s.hasOwnProperty("superTrack") && !s.hasOwnProperty("bigDataUrl")) ||
                     s.hasOwnProperty("compositeTrack") || s.hasOwnProperty("view") ||
-                    (s.hasOwnProperty("container") && (s.getOwnProperty("container") == "multiWig"))
+                    (s.hasOwnProperty("container") && (s.getOwnProperty("container") === "multiWig"))
 
                 // Find parent, if any. "group" containers can be implicit, all other types should be explicitly
                 // defined before their children


### PR DESCRIPTION
Replaced missing "equals" function with "==".

Apparently, at least for the track hub I attempted to use, property "container" is a string and does not have ".equals" method.  Replacing it with '==' "works for me".