### PR TITLE
adds lineWidth property; adds example

### DIFF
--- a/examples/wig-lines.html
+++ b/examples/wig-lines.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>igv.js</title>
+</head>
+
+<body>
+
+<h1>BigWig as lines</h1>
+
+<p>
+    Two BigWig tracks together, displayed as lines of different width
+</p>
+
+
+<div id="igvDiv" style="padding-top: 10px;padding-bottom: 10px; border:1px solid lightgray"></div>
+
+<script type="module">
+
+    import igv from "../dist/igv.esm.js"
+
+    const config  =
+        {
+            genome: "hg19",
+            locus: "chr4:40,174,668-40,221,204",
+            tracks: [
+                {
+                    name: "Merged",
+                    type: "merged",
+                    alpha: 0.75,
+                    tracks: [
+                        {
+                            "type": "wig",
+                            "format": "bigwig",
+                            "url": "https://www.encodeproject.org/files/ENCFF000ASJ/@@download/ENCFF000ASJ.bigWig",
+                            "color": "red",
+                            "graphType": "line",
+                            "lineWidth": 3
+                        },
+                        {
+                            "type": "wig",
+                            "format": "bigwig",
+                            "url": "https://www.encodeproject.org/files/ENCFF351WPV/@@download/ENCFF351WPV.bigWig",
+                            "color": "green",
+                            "graphType": "line",
+                            "lineWidth": 1
+                        }
+                    ]
+                },
+            ]
+        }
+
+    var igvDiv = document.getElementById("igvDiv")
+
+    igv.createBrowser(igvDiv, config)
+        .then(function (browser) {
+            console.log("Created IGV browser")
+        })
+
+
+</script>
+
+</body>
+
+</html>

--- a/js/feature/wigTrack.js
+++ b/js/feature/wigTrack.js
@@ -20,6 +20,7 @@ class WigTrack extends TrackBase {
         logScale: false,
         windowFunction: 'mean',
         graphType: 'bar',
+        lineWidth: 2,
         normalize: undefined,
         scaleFactor: undefined,
         overflowColor: `rgb(255, 32, 255)`,
@@ -71,6 +72,8 @@ class WigTrack extends TrackBase {
         if ("heatmap" === config.graphType && !config.height) {
             this.height = 20
         }
+
+        this.lineWidth = config.lineWidth || WigTrack.defaults.lineWidth // Set lineWidth from config
     }
 
     async postInit() {
@@ -292,11 +295,11 @@ class WigTrack extends TrackBase {
                     const color = options.alpha ? IGVColor.addAlpha(this.getColorForFeature(f), options.alpha) : this.getColorForFeature(f)
 
                     if (this.graphType === "line") {
+                        const lineWidth = this.lineWidth
+                        const properties = {"fillStyle": color, "strokeStyle": color, "lineWidth": lineWidth};
+
                         if (lastY !== undefined) {
-                            IGVGraphics.strokeLine(ctx, lastPixelEnd, lastY, x, y, {
-                                "fillStyle": color,
-                                "strokeStyle": color
-                            })
+                            IGVGraphics.strokeLine(ctx, lastPixelEnd, lastY, x, y, properties)
                         }
                         IGVGraphics.strokeLine(ctx, x, y, x + width, y, {"fillStyle": color, "strokeStyle": color})
                     } else if (this.graphType === "points") {


### PR DESCRIPTION
Hello,

For some visualisation, it would be nice to change the thickness of the line when `graphType` is set to `line`.

I've made some modifications to the code that renders the wig track and it looks correct:
<img width="1728" height="311" alt="image" src="https://github.com/user-attachments/assets/f55542df-5ec8-4914-9caa-63bd20c82208" />

The line width can be set using the `lineWidth` property in the track definition. An example is available in the `examples` folder.

Does that sound like a valuable addition ?

Cheers!

