### PR TITLE
Fix missing roiUtils import in ROIManager

### DIFF
--- a/js/roi/ROIManager.js
+++ b/js/roi/ROIManager.js
@@ -4,6 +4,7 @@ import {getElementVerticalDimension} from "../util/igvUtils.js"
 import {inferFileFormat} from "../util/fileFormatUtils.js"
 import ROIMenu from "./ROIMenu.js"
 import ROITable from "./ROITable.js"
+import {createRegionKey, parseRegionKey} from './roiUtils.js'
 import {FileUtils} from "../../node_modules/igv-utils/src/index.js"
 
 class ROIManager {


### PR DESCRIPTION
## Problem

Loading `dev/roi/roi.html` throws:

```
ROIManager.js:202 Uncaught (in promise) ReferenceError: createRegionKey is not defined
    at ROIManager.renderROISet (ROIManager.js:202)
```

## Cause

Commit 7ee891fd ("Remove circular dependencies") moved `createRegionKey` and `parseRegionKey` out of `ROIManager.js` into `js/roi/roiUtils.js`. `ROITable.js` got the new import, but `ROIManager.js` — which still calls both functions (`parseRegionKey` at line 191, `createRegionKey` at line 202) — did not.

## Fix

Add the missing import:

```js
import {createRegionKey, parseRegionKey} from './roiUtils.js'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)