### PR TITLE
Fix TypeScript type declaration for custom web search config

### DIFF
--- a/js/igv.d.ts
+++ b/js/igv.d.ts
@@ -515,7 +515,6 @@ interface CreateOptExtras {
         resultsField?:  string;
         geneField?: string;
         snpField?:  string;
-        timeout?: number;
     };
 }
 

--- a/js/igv.d.ts
+++ b/js/igv.d.ts
@@ -508,8 +508,14 @@ interface CreateOptExtras {
 
     search?: {
         url: string;
-        chromosomeField: string;
-        displayName: string;
+        coords?: 0 | 1;
+        chromosomeField?: string;
+        startField?: string;
+        endField?:  string;
+        resultsField?:  string;
+        geneField?: string;
+        snpField?:  string;
+        timeout?: number;
     };
 }
 


### PR DESCRIPTION
Corrects the TypeScript type declarations for a custom search service. 

Current typing looks like this:

    search?: {
        url: string;
        chromosomeField: string;
        displayName: string;
    };

This omits multiple search config fields such as `startField`, `endField`, `resultsField`, etc (docs [here](https://igv.org/doc/igvjs/#Browser-Creation/#search-object-details), although docs are incomplete. You can see the config params consumed [here](https://github.com/igvteam/igv.js/blob/518f27e63e2b43d229b27e349c7947c7c9ab10c4/js/browser.js#L194-L205), or see [this test](https://github.com/igvteam/igv.js/blob/518f27e63e2b43d229b27e349c7947c7c9ab10c4/test/testSearch.js#L18-L27)). The typing seems to be based on [this example](https://github.com/igvteam/igv.js/blob/518f27e63e2b43d229b27e349c7947c7c9ab10c4/dev/misc/customSearchService.html), but the example doesn't seem to be correct. See issue [#2084](https://github.com/igvteam/igv.js/issues/2084) for a longer discussion. 

The biggest obstacle for development is that the current typing has both `chromosomeField` and `displayName` as required fields, when:
- chromosomeField is optional
- displayName isn't used anywhere (discussed in issue [#2084](https://github.com/igvteam/igv.js/issues/2084))

This pr adds in the expected fields, making them optional where it's clear in the code that they are optional. ~This includes the parameter `timeout` which is consumed in a [different part of the code](https://github.com/igvteam/igv.js/blob/518f27e63e2b43d229b27e349c7947c7c9ab10c4/js/searchFeatures.js#L68) than the rest of the config.~ 