### PR TITLE
Dev pages demonstrating the ENCODE WAF CAPTCHA gate

### DIFF
--- a/dev/dev.html
+++ b/dev/dev.html
@@ -138,22 +138,20 @@
     <section>
       <p class="section-label">Alignment</p>
       <div class="grid">
-        <a class="card" href="alignment/bam.html" target="_blank">BAM</a>
-        <a class="card" href="alignment/bam-groupby.html" target="_blank">BAM Groupby</a>
         <a class="card" href="alignment/bam_non-actg.html" target="_blank">BAM Non Actg</a>
         <a class="card" href="alignment/bamCSI.html" target="_blank">BamCSI</a>
         <a class="card" href="alignment/bamNonIndexed.html" target="_blank">BamNonIndexed</a>
         <a class="card" href="alignment/basemods/baseMods.html" target="_blank">BaseMods</a>
-        <a class="card" href="alignment/cram.html" target="_blank">CRAM</a>
         <a class="card" href="alignment/deepcoverage.html" target="_blank">Deepcoverage</a>
         <a class="card" href="alignment/giab.html" target="_blank">Giab</a>
         <a class="card" href="alignment/giab-rna.html" target="_blank">Giab RNA</a>
+        <a class="card" href="alignment/groupby.html" target="_blank">Groupby</a>
         <a class="card" href="alignment/highlightReads.html" target="_blank">HighlightReads</a>
         <a class="card" href="alignment/basemods/ont.html" target="_blank">ONT</a>
         <a class="card" href="alignment/pairedColorOptions.html" target="_blank">PairedColorOptions</a>
+        <a class="card" href="alignment/platinum.html" target="_blank">Platinum</a>
         <a class="card" href="alignment/rna-seq.html" target="_blank">RNA Seq</a>
         <a class="card" href="alignment/small_sequence.html" target="_blank">Small Sequence</a>
-        <a class="card" href="alignment/tlen.html" target="_blank">Tlen</a>
         <a class="card" href="alignment/yc_tags.html" target="_blank">Yc Tags</a>
       </div>
     </section>
@@ -210,9 +208,6 @@
         <a class="card" href="cnvpytor/cnvpytorTrackNoIndex.html" target="_blank">CnvpytorTrackNoIndex</a>
         <a class="card" href="cnvpytor/cnvpytorTrackVCF.html" target="_blank">CnvpytorTrackVCF</a>
         <a class="card" href="cnvpytor/cnvpytorTrackVCF_large.html" target="_blank">CnvpytorTrackVCF Large</a>
-        <a class="card" href="cnvpytor/old/indexed_auto_update.html" target="_blank">Indexed Auto Update</a>
-        <a class="card" href="cnvpytor/old/indexed_explicit_update.html" target="_blank">Indexed Explicit Update</a>
-        <a class="card" href="cnvpytor/old/not_indexed.html" target="_blank">Not Indexed</a>
       </div>
     </section>
 
@@ -232,6 +227,14 @@
         <a class="card" href="datauri/dataURI.html" target="_blank">DataURI</a>
         <a class="card" href="datauri/dataURI_pacbio.html" target="_blank">DataURI Pacbio</a>
         <a class="card" href="datauri/ucsc-interact3.html" target="_blank">Ucsc Interact3</a>
+      </div>
+    </section>
+
+    <section>
+      <p class="section-label">ENCODE</p>
+      <div class="grid">
+        <a class="card" href="encode/encode-captcha-gate.html" target="_blank">Encode Captcha Gate</a>
+        <a class="card" href="encode/see-the-captcha.html" target="_blank">See The Captcha</a>
       </div>
     </section>
 
@@ -274,7 +277,6 @@
       <div class="grid">
         <a class="card" href="htsget/htsget.html" target="_blank">Htsget</a>
         <a class="card" href="htsget/htsget-bam.html" target="_blank">Htsget BAM</a>
-        <a class="card" href="htsget/umccr.workers.dev.html" target="_blank">Umccr.Workers.Dev</a>
       </div>
     </section>
 
@@ -292,6 +294,7 @@
         <a class="card" href="interact/embedded.html" target="_blank">Embedded</a>
         <a class="card" href="interact/encode-interact.html" target="_blank">Encode Interact</a>
         <a class="card" href="interact/encode-tsv.html" target="_blank">Encode TSV</a>
+        <a class="card" href="interact/longrange.html" target="_blank">Longrange</a>
         <a class="card" href="interact/svg-ellipse.html" target="_blank">SVG Ellipse</a>
         <a class="card" href="interact/ucsc-interact.html" target="_blank">Ucsc Interact</a>
         <a class="card" href="interact/ucsc-interact2.html" target="_blank">Ucsc Interact2</a>
@@ -325,10 +328,8 @@
         <a class="card" href="misc/functional-url.html" target="_blank">Functional Url</a>
         <a class="card" href="misc/igv-links.html" target="_blank">Igv Links</a>
         <a class="card" href="misc/interactive-filtering.html" target="_blank">Interactive Filtering</a>
-        <a class="card" href="misc/issue_2072.html" target="_blank">Issue 2072</a>
         <a class="card" href="misc/maf_tcga.html" target="_blank">MAF Tcga</a>
         <a class="card" href="misc/multiple-browsers.html" target="_blank">Multiple Browsers</a>
-        <a class="card" href="misc/numeric_seq_names.html" target="_blank">Numeric Seq Names</a>
         <a class="card" href="misc/overhanging_softclips.html" target="_blank">Overhanging Softclips</a>
         <a class="card" href="misc/reports.html" target="_blank">Reports</a>
         <a class="card" href="misc/s3.html" target="_blank">S3</a>
@@ -426,6 +427,7 @@
         <a class="card" href="variant/hubFormats.html" target="_blank">HubFormats</a>
         <a class="card" href="variant/indel.html" target="_blank">Indel</a>
         <a class="card" href="variant/noheader.html" target="_blank">Noheader</a>
+        <a class="card" href="variant/sampleNamesButtonTest.html" target="_blank">SampleNamesButtonTest</a>
         <a class="card" href="variant/sortByGenotype.html" target="_blank">SortByGenotype</a>
         <a class="card" href="variant/vcf_bnd.html" target="_blank">VCF BND</a>
         <a class="card" href="variant/vcf_cnv.html" target="_blank">VCF CNV</a>

--- a/dev/encode/encode-captcha-gate.html
+++ b/dev/encode/encode-captcha-gate.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>IGV - ENCODE CAPTCHA gate</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            color: #111;
+            padding: 1.5rem;
+            max-width: 1100px;
+            margin: 0 auto;
+        }
+
+        h1 { font-size: 1.5rem; margin-bottom: 0.5rem; }
+
+        h2 { font-size: 1rem; margin: 2rem 0 0.5rem; }
+
+        p, li { line-height: 1.5; font-size: 0.9rem; }
+
+        pre, code { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 0.8rem; }
+
+        pre {
+            background: #f5f5f5;
+            border: 1px solid #e0e0e0;
+            border-radius: 4px;
+            padding: 0.75rem;
+            overflow-x: auto;
+        }
+
+        table { border-collapse: collapse; width: 100%; margin-top: 0.5rem; }
+
+        th, td {
+            border: 1px solid #e0e0e0;
+            padding: 0.4rem 0.6rem;
+            font-size: 0.85rem;
+            text-align: left;
+            vertical-align: top;
+        }
+
+        th { background: #f5f5f5; font-weight: 600; }
+
+        .verdict { font-weight: 600; }
+
+        .pass { color: #1a7f37; }
+
+        .fail { color: #b42318; }
+
+        .pending { color: #888; }
+
+        .note {
+            background: #fffbe6;
+            border: 1px solid #f0e0a0;
+            border-radius: 4px;
+            padding: 0.75rem;
+            font-size: 0.85rem;
+            line-height: 1.5;
+        }
+
+        #igvDiv { padding-top: 1rem; }
+    </style>
+</head>
+
+<body>
+
+<h1>ENCODE CAPTCHA gate</h1>
+
+<p>
+    ENCODE fronts <code>www.encodeproject.org</code> with an AWS WAF that inspects the <b>Origin</b> of every request.
+    Approved origins (<code>https://igv.org</code>, <code>https://aidenlab.org</code>, …) are served. Everything else
+    that looks like a real browser gets a CAPTCHA challenge, returned with the misleading status
+    <code>405 Method Not Allowed</code> and the header <code>x-amzn-waf-action: captcha</code>.
+</p>
+
+<p>
+    <code>localhost</code> is not on the approved list and never will be, so <b>no ENCODE-hosted track can be loaded by
+    any igv.js-based app running locally</b>. This page reproduces that.
+</p>
+
+<p>This page is currently served from origin <code id="origin"></code>.</p>
+
+<div class="note">
+    <b>Expected result when served from localhost:</b> the control fetch succeeds, the ENCODE fetches fail, and the
+    ENCODE tracks below never draw while the genome, refseq annotations, and the non-ENCODE bigWig do.
+    <b>Served from <code>https://igv.org</code>, everything succeeds</b> — that asymmetry is the whole bug.
+    <br><br>
+    Note that the challenge response <i>is</i> readable from page JavaScript: measured against the live host it carries
+    <code>access-control-allow-origin: *</code> and, better still,
+    <code>access-control-expose-headers: x-amzn-waf-action</code>. So a fetch here can read both the <code>405</code>
+    and the header naming the real cause — this is not a CORS failure, and the information needed to report
+    <i>"the provider blocked us"</i> instead of <i>"405"</i> is available in the browser.
+</div>
+
+<h2>1. Raw fetch probes</h2>
+
+<table>
+    <thead>
+    <tr>
+        <th style="width: 22%">Host</th>
+        <th style="width: 18%">Gated?</th>
+        <th style="width: 15%">Result</th>
+        <th>Detail</th>
+    </tr>
+    </thead>
+    <tbody id="probeBody"></tbody>
+</table>
+
+<h2>2. The same thing through igv.js</h2>
+
+<p>
+    Three tracks are loaded below: two ENCODE-hosted bigWigs (from the Spacewalk session in the write-up) and one
+    bigWig from a host that does not gate. Load errors are reported here and in the console.
+</p>
+
+<table>
+    <thead>
+    <tr>
+        <th style="width: 40%">Track</th>
+        <th style="width: 15%">Result</th>
+        <th>Detail</th>
+    </tr>
+    </thead>
+    <tbody id="trackBody"></tbody>
+</table>
+
+<div id="igvDiv"></div>
+
+<h2>3. Reproducing it outside the browser</h2>
+
+<p>
+    <code>curl</code> is waved through by default because it does not claim to be a browser — which is why this
+    looks like a CORS problem at first. You have to send a browser User-Agent <i>and</i> a non-approved Origin
+    together to see the gate fire:
+</p>
+
+<pre id="curlRepro"></pre>
+
+<script type="module">
+
+    import igv from "../../js/index.js"
+
+    const ENCODE_BIGWIG_1 = "https://www.encodeproject.org/files/ENCFF809PHW/@@download/ENCFF809PHW.bigWig"
+    const ENCODE_BIGWIG_2 = "https://www.encodeproject.org/files/ENCFF091XDV/@@download/ENCFF091XDV.bigWig"
+    const UNGATED_BIGWIG = "https://human-dev-multiome-atlas.s3.amazonaws.com/tracks/Adrenal_c1/Adrenal_c1.pval.signal.bw"
+
+    document.getElementById("origin").textContent = window.location.origin
+
+    document.getElementById("curlRepro").textContent =
+        `U=${ENCODE_BIGWIG_1}\n` +
+        `UA='Mozilla/5.0 (Macintosh) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'\n` +
+        `\n` +
+        `# Waved through - curl is not a browser\n` +
+        `curl -sI "$U" | head -1\n` +
+        `# HTTP/2 307\n` +
+        `\n` +
+        `# The real thing - browser User-Agent plus this page's origin\n` +
+        `curl -sI -H 'Origin: ${window.location.origin}' -H "User-Agent: $UA" "$U" \\\n` +
+        `  | grep -iE '^HTTP|waf-action'\n` +
+        `# HTTP/2 405\n` +
+        `# x-amzn-waf-action: captcha`
+
+    // ---- Section 1: raw fetch probes ------------------------------------------------------------
+
+    const probes = [
+        {label: "www.encodeproject.org", gated: "yes - Origin gated", url: ENCODE_BIGWIG_1, expect: "fail"},
+        {label: "www.encodeproject.org", gated: "yes - Origin gated", url: ENCODE_BIGWIG_2, expect: "fail"},
+        {label: "s3.amazonaws.com", gated: "no - control", url: UNGATED_BIGWIG, expect: "pass"}
+    ]
+
+    const probeBody = document.getElementById("probeBody")
+
+    for (const probe of probes) {
+        const row = probeBody.insertRow()
+        row.insertCell().innerHTML = `<code>${probe.label}</code><br><code style="color:#888">${probe.url.substring(probe.url.lastIndexOf("/") + 1)}</code>`
+        row.insertCell().textContent = probe.gated
+        const resultCell = row.insertCell()
+        const detailCell = row.insertCell()
+        resultCell.className = "verdict pending"
+        resultCell.textContent = "…"
+
+        // A range request, exactly as a bigWig reader would issue it.
+        fetch(probe.url, {headers: {Range: "bytes=0-64"}})
+            .then(response => {
+                const wafAction = response.headers.get("x-amzn-waf-action")
+                if (wafAction) {
+                    resultCell.className = "verdict fail"
+                    resultCell.textContent = "BLOCKED"
+                    detailCell.innerHTML = `HTTP <code>${response.status}</code>, <code>x-amzn-waf-action: ${wafAction}</code> — the WAF challenge.`
+                } else if (response.ok) {
+                    resultCell.className = "verdict pass"
+                    resultCell.textContent = "OK"
+                    detailCell.innerHTML = `HTTP <code>${response.status}</code>, ${response.headers.get("content-length") || "?"} bytes.`
+                } else {
+                    resultCell.className = "verdict fail"
+                    resultCell.textContent = "FAILED"
+                    detailCell.innerHTML = `HTTP <code>${response.status} ${response.statusText}</code>.`
+                }
+            })
+            .catch(error => {
+                resultCell.className = "verdict fail"
+                resultCell.textContent = "BLOCKED"
+                detailCell.innerHTML =
+                    `<code>${error.name}: ${error.message}</code><br>` +
+                    `The fetch rejected outright, so no status or headers reached this page. ` +
+                    `Check the Network tab for the real response — expect <code>405</code> with ` +
+                    `<code>x-amzn-waf-action: captcha</code>.`
+                console.log(`Probe failed: ${probe.url}`, error)
+            })
+    }
+
+    // ---- Section 2: the same URLs through igv.js -------------------------------------------------
+
+    const tracks = [
+        {name: "Homo sapiens 22Rv1 CTCF (ENCFF809PHW)", url: ENCODE_BIGWIG_1, format: "bigwig", color: "rgb(0,0,150)"},
+        {name: "Homo sapiens 22Rv1 CTCF (ENCFF091XDV)", url: ENCODE_BIGWIG_2, format: "bigwig", color: "rgb(0,0,150)"},
+        {name: "Control - not an ENCODE host", url: UNGATED_BIGWIG, format: "bigwig", color: "rgb(0,150,0)"}
+    ]
+
+    const trackBody = document.getElementById("trackBody")
+
+    const browser = await igv.createBrowser(document.getElementById("igvDiv"), {
+        genome: "hg38",
+        locus: "chr8:127,736,588-127,739,371"
+    })
+
+    for (const track of tracks) {
+        const row = trackBody.insertRow()
+        row.insertCell().textContent = track.name
+        const resultCell = row.insertCell()
+        const detailCell = row.insertCell()
+        resultCell.className = "verdict pending"
+        resultCell.textContent = "…"
+
+        try {
+            await browser.loadTrack(track)
+            resultCell.className = "verdict pass"
+            resultCell.textContent = "LOADED"
+            detailCell.textContent = "Track loaded and drawn."
+        } catch (error) {
+            resultCell.className = "verdict fail"
+            resultCell.textContent = "FAILED"
+            detailCell.innerHTML =
+                `<code>${error.message}</code><br>` +
+                `Note how little this says about the actual cause — a data provider refused the request ` +
+                `because this page's origin is not on its approved list.`
+            console.log(`Track load failed: ${track.url}`, error)
+        }
+    }
+
+</script>
+
+</body>
+
+</html>

--- a/dev/encode/see-the-captcha.html
+++ b/dev/encode/see-the-captcha.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>IGV - See the ENCODE CAPTCHA</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            color: #111;
+            padding: 1.5rem;
+            max-width: 900px;
+            margin: 0 auto;
+        }
+
+        h1 { font-size: 1.6rem; margin-bottom: 0.5rem; }
+
+        h2 { font-size: 1.05rem; margin: 2.25rem 0 0.5rem; }
+
+        p, li { line-height: 1.55; font-size: 0.92rem; }
+
+        code, pre { font-family: ui-monospace, Menlo, Consolas, monospace; font-size: 0.8rem; }
+
+        pre {
+            background: #f5f5f5;
+            border: 1px solid #e0e0e0;
+            border-radius: 4px;
+            padding: 0.75rem;
+            overflow-x: auto;
+            max-height: 320px;
+        }
+
+        .cta {
+            display: inline-block;
+            background: #b42318;
+            color: #fff;
+            text-decoration: none;
+            font-size: 0.95rem;
+            font-weight: 600;
+            padding: 0.7rem 1.2rem;
+            border: none;
+            border-radius: 6px;
+            cursor: pointer;
+            margin: 0.25rem 0.5rem 0.25rem 0;
+        }
+
+        .cta:hover { background: #91170f; }
+
+        .cta.secondary { background: #444; }
+
+        .cta.secondary:hover { background: #222; }
+
+        .note {
+            background: #fffbe6;
+            border: 1px solid #f0e0a0;
+            border-radius: 4px;
+            padding: 0.75rem;
+            font-size: 0.88rem;
+            line-height: 1.55;
+            margin: 1rem 0;
+        }
+
+        iframe {
+            width: 100%;
+            height: 520px;
+            border: 2px solid #b42318;
+            border-radius: 6px;
+            background: #fff;
+            margin-top: 0.75rem;
+        }
+
+        .hidden { display: none; }
+
+        .url {
+            word-break: break-all;
+            background: #f5f5f5;
+            padding: 0.4rem 0.6rem;
+            border-radius: 4px;
+            display: inline-block;
+        }
+    </style>
+</head>
+
+<body>
+
+<h1>The ENCODE CAPTCHA, actually presented</h1>
+
+<p>
+    Every discussion of this problem so far has been about a <code>405</code> status and an
+    <code>x-amzn-waf-action: captcha</code> header. But there is a real, human-facing CAPTCHA behind those — an AWS WAF
+    "Human Verification" page with an actual puzzle widget. This page puts it on your screen.
+</p>
+
+<p>The URL being requested is an ordinary ENCODE bigWig, the kind any igv.js track config would point at:</p>
+
+<p><code class="url" id="targetUrl"></code></p>
+
+<div class="note">
+    <b>Use a private/incognito window.</b> Once you solve a WAF challenge, AWS stores an <code>aws-waf-token</code> for
+    the host and waves you through for a while — so on a second visit you may get the file instead of the puzzle. A
+    fresh private window is the reliable way to see it. If you get a file download rather than a challenge, that is
+    what happened.
+</div>
+
+<h2>1. Click through to it directly</h2>
+
+<p>
+    This is a plain top-level navigation — no igv.js, no JavaScript, no <code>Origin</code> header at all. The WAF
+    challenges it purely because the request comes from something that looks like a browser. Opens in a new tab.
+</p>
+
+<p>
+    <a class="cta" id="directLink" href="#" target="_blank" rel="noopener">Open the ENCODE file in a new tab</a>
+</p>
+
+<h2>2. Or watch it render right here</h2>
+
+<p>
+    The challenge response sets no <code>X-Frame-Options</code> and no framing CSP, so it will render inline. Click
+    below and the AWS WAF puzzle loads in the frame — the same widget, live from
+    <code>captcha.awswaf.com</code>. You can actually solve it.
+</p>
+
+<p>
+    <button class="cta" id="loadFrame">Present the CAPTCHA below</button>
+    <button class="cta secondary" id="clearFrame">Clear</button>
+</p>
+
+<iframe id="captchaFrame" class="hidden" title="ENCODE WAF challenge"></iframe>
+
+<h2>3. What igv.js gets instead of your data</h2>
+
+<p>
+    This is the point of the whole exercise. When a bigWig reader issues its range request, <b>this HTML is the
+    response body</b> — served where the first bytes of a binary file should be. The reader has no idea it is looking
+    at a CAPTCHA page; it tries to parse it as a bigWig header, finds a bad magic number, and reports something
+    unrelated to what actually happened.
+</p>
+
+<p>
+    <button class="cta secondary" id="showBody">Fetch the response body igv.js would receive</button>
+</p>
+
+<pre id="bodyOut" class="hidden"></pre>
+
+<p id="statusLine"></p>
+
+<script type="module">
+
+    // An ordinary ENCODE-hosted bigWig - the same file referenced from the Spacewalk session
+    // in the "url mapping and the ENCODE gate" write-up.
+    const ENCODE_BIGWIG = "https://www.encodeproject.org/files/ENCFF809PHW/@@download/ENCFF809PHW.bigWig"
+
+    document.getElementById("targetUrl").textContent = ENCODE_BIGWIG
+    document.getElementById("directLink").href = ENCODE_BIGWIG
+
+    const frame = document.getElementById("captchaFrame")
+
+    document.getElementById("loadFrame").addEventListener("click", () => {
+        frame.src = ENCODE_BIGWIG
+        frame.classList.remove("hidden")
+        frame.scrollIntoView({behavior: "smooth", block: "center"})
+    })
+
+    document.getElementById("clearFrame").addEventListener("click", () => {
+        frame.removeAttribute("src")
+        frame.classList.add("hidden")
+    })
+
+    document.getElementById("showBody").addEventListener("click", async () => {
+        const out = document.getElementById("bodyOut")
+        const status = document.getElementById("statusLine")
+        out.classList.remove("hidden")
+        out.textContent = "Fetching…"
+        status.textContent = ""
+
+        try {
+            // A range request, exactly as a bigWig reader would issue it.
+            const response = await fetch(ENCODE_BIGWIG, {headers: {Range: "bytes=0-65535"}})
+            const wafAction = response.headers.get("x-amzn-waf-action")
+            const text = await response.text()
+
+            out.textContent = text
+            status.innerHTML = wafAction
+                ? `HTTP <code>${response.status}</code>, <code>x-amzn-waf-action: ${wafAction}</code>. ` +
+                  `Those ${text.length} bytes of HTML are what the bigWig reader was handed in place of your data.`
+                : `HTTP <code>${response.status}</code> — no WAF challenge on this request. ` +
+                  `You are probably carrying an <code>aws-waf-token</code> from a previous visit; try a private window.`
+        } catch (error) {
+            out.textContent = `${error.name}: ${error.message}`
+            status.textContent =
+                "The fetch rejected outright, so nothing reached this page - check the Network tab for the real response."
+        }
+    })
+
+</script>
+
+</body>
+
+</html>

--- a/scripts/buildDevDashboard.cjs
+++ b/scripts/buildDevDashboard.cjs
@@ -51,6 +51,7 @@ function toSectionLabel(dirname) {
         'cbio': 'cBio',
         'cnvpytor': 'CNVpytor',
         'datauri': 'Data URI',
+        'encode': 'ENCODE',
         'gwas': 'GWAS',
         'hic': 'Hi-C',
         'htsget': 'htsget',


### PR DESCRIPTION
## Why

ENCODE fronts `www.encodeproject.org` with an AWS WAF that challenges browser-looking requests, returning `405 Method Not Allowed` with `x-amzn-waf-action: captcha`. The status code is misleading — nothing about the request used the wrong verb — so the failure sends you looking in the wrong place. The practical cost is that no igv.js-based app can load ENCODE tracks during local development, and we can't reproduce user-reported bugs involving ENCODE data on our own machines.

Everything written about this so far has been about a status code and a header. Neither of us had actually seen the CAPTCHA.

## What's here

**`dev/encode/see-the-captcha.html`** — presents the challenge to a human. The key finding: **the WAF challenges a plain top-level navigation**, with no `Origin` header, no localhost, and no igv.js involved. Clicking a link to an ENCODE bigWig renders a live AWS WAF "Human Verification" page with a solvable puzzle widget loaded from `captcha.awswaf.com`. The page offers three views:

1. A button opening the ENCODE file in a new tab — the challenge, straight up
2. The same challenge rendered inline in an iframe (the response sets no `X-Frame-Options` and no framing CSP)
3. A button dumping the raw 2119 bytes of challenge HTML that a bigWig reader receives in place of binary data — which is why the reader reports a bad magic number rather than "you were blocked"

**`dev/encode/encode-captcha-gate.html`** — the diagnostic view. Raw range-request probes against two gated ENCODE bigWigs plus an ungated control, the same URLs loaded through igv.js so the partial-page failure is visible, and a copy-pasteable `curl` repro built from the page's own origin.

## Measurements against the live host

```
browser UA, NO Origin (i.e. clicking a link)  → 405 + x-amzn-waf-action: captcha
browser UA, no Origin, + navigation Sec-Fetch → 405
browser UA + localhost Origin (the xhr case)  → 405
plain curl (honest User-Agent)                → 307
```

One correction to the internal write-up this came from: **the challenge response is fully readable from page JavaScript.** It carries `access-control-allow-origin: *` and, notably, `access-control-expose-headers: x-amzn-waf-action`. This is not a CORS failure, and reporting *"this data provider blocked the request"* instead of *"405"* needs no server-side cooperation — the honest signal is already reachable in the browser.

## Also

Adds an `'encode' -> 'ENCODE'` section label to `scripts/buildDevDashboard.cjs` and regenerates `dev/dev.html`.

## Testing notes

Use a **private/incognito window**. Solving a WAF challenge earns an `aws-waf-token` for the host that waves you through afterward, so a repeat visit may hand you a file download instead of the puzzle. Both pages warn about this.

These are dev pages only — no library code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)